### PR TITLE
feat(web): Sprint UI Components - XPBar, BadgeGrid, LevelBadge, Animations, Polish

### DIFF
--- a/apps/web/global.css
+++ b/apps/web/global.css
@@ -1,3 +1,102 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Animation Keyframes */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(10px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes glow {
+  0%, 100% {
+    box-shadow: 0 0 5px rgba(59, 130, 246, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 20px rgba(59, 130, 246, 0.8);
+  }
+}
+
+@keyframes bounceSubtle {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+/* Animation Utility Classes */
+.animate-in {
+  animation: fadeIn 0.2s ease-out, slideUp 0.3s ease-out;
+}
+
+.animate-glow {
+  animation: glow 2s ease-in-out infinite;
+}
+
+.animate-bounce-subtle {
+  animation: bounceSubtle 2s ease-in-out infinite;
+}
+
+.animate-shimmer {
+  animation: shimmer 2s linear infinite;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+  background-size: 200% 100%;
+}
+
+/* Custom scrollbar for web */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: #1f2937; } /* bg-gray-800 */
+::-webkit-scrollbar-thumb { background: #4b5563; border-radius: 9999px; } /* bg-gray-600 rounded-full */
+::-webkit-scrollbar-thumb:hover { background: #6b7280; } /* bg-gray-500 */
+
+/* Focus states */
+:focus-visible { outline: none; ring: 2px solid #3b82f6; ring-offset: 2px; ring-offset-color: #111827; }
+
+/* Text gradient utility */
+.text-gradient { background: linear-gradient(to right, #60a5fa, #a78bfa); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }

--- a/apps/web/src/components/molecules/BadgeGrid.tsx
+++ b/apps/web/src/components/molecules/BadgeGrid.tsx
@@ -1,0 +1,106 @@
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+
+export interface Badge {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  unlockedAt?: Date;
+}
+
+export interface BadgeGridProps {
+  badges: Badge[];
+  unlockedBadgeIds: string[];
+  onBadgePress?: (badge: Badge) => void;
+}
+
+export function BadgeGrid({ badges, unlockedBadgeIds, onBadgePress }: BadgeGridProps) {
+  const isUnlocked = (badgeId: string) => unlockedBadgeIds.includes(badgeId);
+
+  return (
+    <View style={styles.grid}>
+      {badges.map((badge) => {
+        const unlocked = isUnlocked(badge.id);
+
+        return (
+          <Pressable
+            key={badge.id}
+            style={[styles.badgeItem, unlocked ? styles.badgeItemUnlocked : styles.badgeItemLocked]}
+            onPress={() => onBadgePress?.(badge)}
+            disabled={!onBadgePress}
+            testID={`badge-${badge.id}`}
+          >
+            <View
+              style={[
+                styles.iconContainer,
+                unlocked ? styles.iconContainerUnlocked : styles.iconContainerLocked,
+              ]}
+            >
+              <Text style={[styles.icon, unlocked ? styles.iconUnlocked : styles.iconLocked]}>
+                {badge.icon}
+              </Text>
+            </View>
+            <Text style={styles.badgeName} numberOfLines={2}>
+              {badge.name}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 16,
+  },
+  badgeItem: {
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 8,
+    borderRadius: 12,
+    padding: 12,
+    // Calculate width to fit 4 columns on mobile, 8 on larger screens
+    // Using percentage with gap: (100% - (3 * gap)) / 4 ≈ 22%
+    width: '22%',
+    minWidth: 70,
+  },
+  badgeItemUnlocked: {
+    backgroundColor: '#1F2937', // gray-800
+    opacity: 1,
+  },
+  badgeItemLocked: {
+    backgroundColor: 'transparent',
+    opacity: 0.3,
+  },
+  iconContainer: {
+    borderRadius: 9999, // full rounded
+    padding: 8,
+    width: 48,
+    height: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  iconContainerUnlocked: {
+    backgroundColor: 'rgba(147, 51, 234, 0.2)', // primary-500/20 (purple)
+  },
+  iconContainerLocked: {
+    backgroundColor: '#374151', // gray-700
+  },
+  icon: {
+    fontSize: 24,
+  },
+  iconUnlocked: {
+    color: '#c084fc', // primary-400 (purple-400)
+  },
+  iconLocked: {
+    color: '#6B7280', // gray-500
+  },
+  badgeName: {
+    fontSize: 12,
+    color: '#9CA3AF', // gray-400
+    textAlign: 'center',
+  },
+});

--- a/apps/web/src/components/molecules/LessonCard.tsx
+++ b/apps/web/src/components/molecules/LessonCard.tsx
@@ -1,64 +1,227 @@
-import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { View, Text, StyleSheet, Pressable, Animated } from 'react-native';
+import { CheckCircle2, Lock, Clock, Award, Play, BookOpen } from 'lucide-react-native';
+import { Icon } from '@/components/ui/Icon';
 import type { Lesson } from '@llmengineer/shared';
+import { useRef, useEffect } from 'react';
 
-interface LessonCardProps {
+export type LessonStatus = 'locked' | 'available' | 'in_progress' | 'completed';
+
+export interface LessonCardProps {
   lesson: Lesson;
   onPress: () => void;
+  status?: LessonStatus;
+  isLocked?: boolean;
 }
 
-export function LessonCard({ lesson, onPress }: LessonCardProps) {
+export function LessonCard({ lesson, onPress, status, isLocked = false }: LessonCardProps) {
   const difficultyColors = {
     beginner: '#10B981',
     intermediate: '#F59E0B',
     advanced: '#EF4444',
   };
 
+  // Determine lesson status automatically if not provided
+  const lessonStatus: LessonStatus =
+    status || (isLocked ? 'locked' : lesson.isCompleted ? 'completed' : 'available');
+
+  // Pulsing animation for in-progress state
+  const pulseAnim = useRef(new Animated.Value(1)).current;
+  const scaleAnim = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (lessonStatus === 'in_progress') {
+      // Create pulsing animation
+      Animated.loop(
+        Animated.sequence([
+          Animated.timing(pulseAnim, {
+            toValue: 1.2,
+            duration: 1500,
+            useNativeDriver: true,
+          }),
+          Animated.timing(pulseAnim, {
+            toValue: 1,
+            duration: 1500,
+            useNativeDriver: true,
+          }),
+        ])
+      ).start();
+    }
+  }, [lessonStatus, pulseAnim]);
+
+  const handlePress = () => {
+    if (lessonStatus === 'locked') return;
+    onPress();
+  };
+
+  const handlePressIn = () => {
+    if (lessonStatus === 'locked') return;
+    Animated.spring(scaleAnim, {
+      toValue: 0.98,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const handlePressOut = () => {
+    if (lessonStatus === 'locked') return;
+    Animated.spring(scaleAnim, {
+      toValue: 1,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const getBorderColor = () => {
+    switch (lessonStatus) {
+      case 'in_progress':
+        return '#3b82f6'; // primary-500
+      case 'completed':
+        return '#22c55e'; // green-500
+      default:
+        return '#374151'; // gray-700
+    }
+  };
+
+  const getBackgroundColor = () => {
+    return lessonStatus === 'completed' ? '#0f1e13' : '#1F2937';
+  };
+
+  const getIconForStatus = () => {
+    switch (lessonStatus) {
+      case 'locked':
+        return <Icon icon={Lock} size="lg" color="#64748b" />;
+      case 'completed':
+        return <Icon icon={CheckCircle2} size="lg" color="#22c55e" />;
+      case 'in_progress':
+        return <Icon icon={Play} size="lg" color="#3b82f6" />;
+      default:
+        return <Icon icon={BookOpen} size="lg" color="#94a3b8" />;
+    }
+  };
+
   return (
-    <Pressable style={styles.container} onPress={onPress}>
-      <View style={styles.content}>
-        <View style={styles.header}>
-          <Text style={styles.weekBadge}>Semana {lesson.week}</Text>
+    <Animated.View style={{ transform: [{ scale: scaleAnim }] }}>
+      <Pressable
+        style={[
+          styles.container,
+          {
+            backgroundColor: getBackgroundColor(),
+            borderColor: getBorderColor(),
+            opacity: lessonStatus === 'locked' ? 0.6 : 1,
+            cursor: lessonStatus === 'locked' ? 'not-allowed' : 'pointer',
+          } as any,
+        ]}
+        onPress={handlePress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        disabled={lessonStatus === 'locked'}
+      >
+        {/* Pulsing indicator for in-progress state */}
+        {lessonStatus === 'in_progress' && (
+          <Animated.View
+            style={[
+              styles.pulsingIndicator,
+              {
+                transform: [{ scale: pulseAnim }],
+              },
+            ]}
+          />
+        )}
+
+        <View style={styles.content}>
+          {/* Header with badges */}
+          <View style={styles.header}>
+            <View style={styles.leftBadges}>
+              <Text style={styles.weekBadge}>Semana {lesson.week}</Text>
+              <View
+                style={[
+                  styles.difficultyBadge,
+                  { backgroundColor: difficultyColors[lesson.difficulty] + '20' },
+                ]}
+              >
+                <Text
+                  style={[styles.difficultyText, { color: difficultyColors[lesson.difficulty] }]}
+                >
+                  {lesson.difficulty}
+                </Text>
+              </View>
+            </View>
+            {lessonStatus === 'locked' && (
+              <View style={styles.lockedBadge}>
+                <Icon icon={Lock} size="sm" color="#64748b" />
+              </View>
+            )}
+          </View>
+
+          {/* Lesson icon */}
           <View
             style={[
-              styles.difficultyBadge,
-              { backgroundColor: difficultyColors[lesson.difficulty] + '20' },
+              styles.lessonIcon,
+              lessonStatus === 'completed' && styles.lessonIconComplete,
+              lessonStatus === 'in_progress' && styles.lessonIconInProgress,
+              lessonStatus === 'locked' && styles.lessonIconLocked,
             ]}
           >
-            <Text style={[styles.difficultyText, { color: difficultyColors[lesson.difficulty] }]}>
-              {lesson.difficulty}
-            </Text>
+            {getIconForStatus()}
+          </View>
+
+          {/* Title and description */}
+          <Text style={styles.title}>{lesson.title}</Text>
+          <Text style={styles.description} numberOfLines={2}>
+            {lesson.description}
+          </Text>
+
+          {/* Meta information */}
+          <View style={styles.footer}>
+            <View style={styles.metaRow}>
+              <View style={styles.xpBadge}>
+                <Icon icon={Award} size="xs" color="#10B981" />
+                <Text style={styles.xpText}>+{lesson.xpReward} XP</Text>
+              </View>
+              <View style={styles.timeBadge}>
+                <Icon icon={Clock} size="xs" color="#6B7280" />
+                <Text style={styles.duration}>{lesson.estimatedMinutes} min</Text>
+              </View>
+            </View>
+            {lessonStatus !== 'locked' && (
+              <View style={styles.actionIndicator}>
+                {lessonStatus === 'completed' ? (
+                  <Text style={styles.actionTextCompleted}>Completado</Text>
+                ) : lessonStatus === 'in_progress' ? (
+                  <Text style={styles.actionTextInProgress}>Continuar</Text>
+                ) : (
+                  <Text style={styles.actionText}>Comenzar</Text>
+                )}
+              </View>
+            )}
           </View>
         </View>
 
-        <Text style={styles.title}>{lesson.title}</Text>
-        <Text style={styles.description} numberOfLines={2}>
-          {lesson.description}
-        </Text>
-
-        <View style={styles.footer}>
-          <View style={styles.xpBadge}>
-            <Text style={styles.xpText}>+{lesson.xpReward} XP</Text>
+        {/* Completed overlay badge */}
+        {lessonStatus === 'completed' && (
+          <View style={styles.completedOverlay}>
+            <Icon icon={CheckCircle2} size="md" color="#FFFFFF" />
           </View>
-          <Text style={styles.duration}>{lesson.estimatedMinutes} min</Text>
-        </View>
-      </View>
-
-      {lesson.isCompleted && (
-        <View style={styles.completedOverlay}>
-          <Text style={styles.completedIcon}>✓</Text>
-        </View>
-      )}
-    </Pressable>
+        )}
+      </Pressable>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#1F2937',
     borderRadius: 12,
     overflow: 'hidden',
-    borderWidth: 1,
-    borderColor: '#374151',
+    borderWidth: 2,
+    position: 'relative',
+  },
+  pulsingIndicator: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#3b82f6',
+    zIndex: 10,
   },
   content: {
     padding: 16,
@@ -68,6 +231,11 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 12,
+  },
+  leftBadges: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
   },
   weekBadge: {
     fontSize: 12,
@@ -88,6 +256,29 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     textTransform: 'capitalize',
   },
+  lockedBadge: {
+    backgroundColor: '#1e293b',
+    padding: 4,
+    borderRadius: 6,
+  },
+  lessonIcon: {
+    width: 56,
+    height: 56,
+    borderRadius: 12,
+    backgroundColor: '#334155',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  lessonIconComplete: {
+    backgroundColor: '#166534',
+  },
+  lessonIconInProgress: {
+    backgroundColor: '#1e3a8a',
+  },
+  lessonIconLocked: {
+    backgroundColor: '#1e293b',
+  },
   title: {
     fontSize: 18,
     fontWeight: '600',
@@ -105,35 +296,69 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
   },
+  metaRow: {
+    flexDirection: 'row',
+    gap: 12,
+    alignItems: 'center',
+  },
   xpBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
     backgroundColor: '#10B98120',
-    paddingHorizontal: 10,
+    paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 12,
   },
   xpText: {
-    fontSize: 14,
+    fontSize: 13,
     fontWeight: '600',
     color: '#10B981',
   },
+  timeBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
   duration: {
-    fontSize: 14,
+    fontSize: 13,
     color: '#6B7280',
+  },
+  actionIndicator: {
+    paddingHorizontal: 8,
+  },
+  actionText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#3b82f6',
+  },
+  actionTextInProgress: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#3b82f6',
+  },
+  actionTextCompleted: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#22c55e',
   },
   completedOverlay: {
     position: 'absolute',
     top: 12,
     right: 12,
-    width: 28,
-    height: 28,
-    borderRadius: 14,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
     backgroundColor: '#10B981',
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  completedIcon: {
-    fontSize: 16,
-    color: '#FFFFFF',
-    fontWeight: 'bold',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
   },
 });

--- a/apps/web/src/components/molecules/LevelBadge.tsx
+++ b/apps/web/src/components/molecules/LevelBadge.tsx
@@ -1,0 +1,95 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { Icon } from '@/components/ui/Icon';
+import type { LucideIcon } from 'lucide-react-native';
+
+export interface Level {
+  level: number;
+  icon: LucideIcon;
+  color: string;
+}
+
+export interface LevelBadgeProps {
+  level: Level;
+  variant?: 'default' | 'minimal';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeConfig = {
+  sm: {
+    iconSize: 16,
+    fontSize: 14,
+    paddingX: 8,
+    paddingY: 4,
+    gap: 6,
+  },
+  md: {
+    iconSize: 20,
+    fontSize: 16,
+    paddingX: 12,
+    paddingY: 6,
+    gap: 8,
+  },
+  lg: {
+    iconSize: 24,
+    fontSize: 18,
+    paddingX: 16,
+    paddingY: 8,
+    gap: 10,
+  },
+} as const;
+
+export function LevelBadge({ level, variant = 'default', size = 'md' }: LevelBadgeProps) {
+  const config = sizeConfig[size];
+
+  if (variant === 'minimal') {
+    return (
+      <View style={[styles.container, styles.minimal, { gap: config.gap }]}>
+        <Icon icon={level.icon} size={size} color={level.color} />
+        <Text style={[styles.text, { fontSize: config.fontSize, color: level.color }]}>
+          {level.level}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        styles.default,
+        {
+          paddingHorizontal: config.paddingX,
+          paddingVertical: config.paddingY,
+          gap: config.gap,
+        },
+      ]}
+    >
+      <Icon icon={level.icon} size={size} color={level.color} />
+      <Text
+        style={[styles.text, styles.levelText, { fontSize: config.fontSize, color: level.color }]}
+      >
+        Lvl {level.level}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  default: {
+    borderRadius: 9999,
+    backgroundColor: 'rgba(55, 65, 81, 0.8)',
+  },
+  minimal: {
+    backgroundColor: 'transparent',
+  },
+  text: {
+    fontWeight: '600',
+  },
+  levelText: {
+    fontWeight: '600',
+  },
+});

--- a/apps/web/src/components/molecules/ModuleCard.tsx
+++ b/apps/web/src/components/molecules/ModuleCard.tsx
@@ -1,16 +1,22 @@
-import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { View, Text, Pressable, StyleSheet, Animated } from 'react-native';
 import { router } from 'expo-router';
-import { CheckCircle2, BookOpen, ChevronRight } from 'lucide-react-native';
+import { CheckCircle2, BookOpen, ChevronRight, Lock, Clock } from 'lucide-react-native';
 import { Icon } from '@/components/ui/Icon';
+import { useRef, useEffect } from 'react';
 
-interface ModuleCardProps {
+export type ModuleStatus = 'locked' | 'available' | 'in_progress' | 'completed';
+
+export interface ModuleCardProps {
   id: string;
   title: string;
   description: string;
   lessonsCompleted: number;
   totalLessons: number;
-  isComplete: boolean;
+  isComplete?: boolean;
+  status?: ModuleStatus;
   iconEmoji?: string;
+  estimatedMinutes?: number;
+  isLocked?: boolean;
 }
 
 export function ModuleCard({
@@ -19,54 +25,216 @@ export function ModuleCard({
   description,
   lessonsCompleted,
   totalLessons,
-  isComplete,
+  isComplete = false,
+  status,
+  iconEmoji,
+  estimatedMinutes,
+  isLocked = false,
 }: ModuleCardProps) {
-  const progressPercent = totalLessons > 0
-    ? Math.round((lessonsCompleted / totalLessons) * 100)
-    : 0;
+  const progressPercent =
+    totalLessons > 0 ? Math.round((lessonsCompleted / totalLessons) * 100) : 0;
+
+  // Determine the module status automatically if not provided
+  const moduleStatus: ModuleStatus =
+    status ||
+    (isLocked
+      ? 'locked'
+      : isComplete
+        ? 'completed'
+        : lessonsCompleted > 0
+          ? 'in_progress'
+          : 'available');
+
+  // Pulsing animation for in-progress state
+  const pulseAnim = useRef(new Animated.Value(1)).current;
+  const scaleAnim = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (moduleStatus === 'in_progress') {
+      // Create pulsing animation
+      Animated.loop(
+        Animated.sequence([
+          Animated.timing(pulseAnim, {
+            toValue: 1.2,
+            duration: 1500,
+            useNativeDriver: true,
+          }),
+          Animated.timing(pulseAnim, {
+            toValue: 1,
+            duration: 1500,
+            useNativeDriver: true,
+          }),
+        ])
+      ).start();
+    }
+  }, [moduleStatus, pulseAnim]);
 
   const handlePress = () => {
+    if (moduleStatus === 'locked') return;
     router.push(`/lessons/?module=${id}` as any);
   };
 
+  const handlePressIn = () => {
+    if (moduleStatus === 'locked') return;
+    Animated.spring(scaleAnim, {
+      toValue: 0.98,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const handlePressOut = () => {
+    if (moduleStatus === 'locked') return;
+    Animated.spring(scaleAnim, {
+      toValue: 1,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const getIconComponent = () => {
+    switch (moduleStatus) {
+      case 'locked':
+        return <Icon icon={Lock} size="lg" color="#64748b" />;
+      case 'completed':
+        return <Icon icon={CheckCircle2} size="lg" color="#22c55e" />;
+      case 'in_progress':
+        return <Icon icon={BookOpen} size="lg" color="#3b82f6" />;
+      default:
+        return <Icon icon={BookOpen} size="lg" color="#94a3b8" />;
+    }
+  };
+
+  const getActionButtonText = () => {
+    switch (moduleStatus) {
+      case 'locked':
+        return 'Bloqueado';
+      case 'completed':
+        return 'Revisar';
+      case 'in_progress':
+        return 'Continuar';
+      default:
+        return 'Comenzar';
+    }
+  };
+
+  const getBorderColor = () => {
+    switch (moduleStatus) {
+      case 'in_progress':
+        return '#3b82f6'; // primary-500
+      case 'completed':
+        return '#22c55e'; // green-500
+      default:
+        return '#334155'; // slate-700
+    }
+  };
+
+  const getBackgroundColor = () => {
+    return moduleStatus === 'completed' ? '#0f1e13' : '#1e293b';
+  };
+
   return (
-    <Pressable style={styles.card} onPress={handlePress}>
-      <View style={styles.header}>
-        <View style={[styles.iconContainer, isComplete && styles.iconContainerComplete]}>
-          {isComplete ? (
-            <Icon icon={CheckCircle2} size="lg" color="#22c55e" />
-          ) : (
-            <Icon icon={BookOpen} size="lg" color="#94a3b8" />
+    <Animated.View style={{ transform: [{ scale: scaleAnim }] }}>
+      <Pressable
+        style={[
+          styles.card,
+          {
+            backgroundColor: getBackgroundColor(),
+            borderColor: getBorderColor(),
+            opacity: moduleStatus === 'locked' ? 0.6 : 1,
+            cursor: moduleStatus === 'locked' ? 'not-allowed' : 'pointer',
+          } as any,
+        ]}
+        onPress={handlePress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        disabled={moduleStatus === 'locked'}
+      >
+        {/* Pulsing indicator for in-progress state */}
+        {moduleStatus === 'in_progress' && (
+          <Animated.View
+            style={[
+              styles.pulsingIndicator,
+              {
+                transform: [{ scale: pulseAnim }],
+              },
+            ]}
+          />
+        )}
+
+        <View style={styles.header}>
+          <View
+            style={[
+              styles.iconContainer,
+              moduleStatus === 'completed' && styles.iconContainerComplete,
+              moduleStatus === 'in_progress' && styles.iconContainerInProgress,
+              moduleStatus === 'locked' && styles.iconContainerLocked,
+            ]}
+          >
+            {iconEmoji ? <Text style={styles.iconEmoji}>{iconEmoji}</Text> : getIconComponent()}
+          </View>
+          {moduleStatus === 'completed' && (
+            <View style={styles.completeBadge}>
+              <Icon icon={CheckCircle2} size="sm" color="#22c55e" />
+            </View>
           )}
         </View>
-        {isComplete && (
-          <View style={styles.completeBadge}>
-            <Icon icon={CheckCircle2} size="sm" color="#22c55e" />
+
+        <Text style={styles.title} numberOfLines={2}>
+          {title}
+        </Text>
+        <Text style={styles.description} numberOfLines={2}>
+          {description}
+        </Text>
+
+        <View style={styles.metaInfo}>
+          <View style={styles.metaRow}>
+            <Text style={styles.lessonsText}>
+              {lessonsCompleted}/{totalLessons} lecciones
+            </Text>
+            {estimatedMinutes && (
+              <View style={styles.timeEstimate}>
+                <Icon icon={Clock} size="xs" color="#64748b" />
+                <Text style={styles.timeText}>{estimatedMinutes} min</Text>
+              </View>
+            )}
           </View>
-        )}
-      </View>
+          <Text style={styles.progressText}>{progressPercent}%</Text>
+        </View>
 
-      <Text style={styles.title} numberOfLines={2}>{title}</Text>
-      <Text style={styles.description} numberOfLines={2}>{description}</Text>
+        {/* Progress bar */}
+        <View style={styles.progressTrack}>
+          <View
+            style={[
+              styles.progressBar,
+              {
+                width: `${progressPercent}%`,
+                backgroundColor:
+                  moduleStatus === 'completed'
+                    ? '#22c55e'
+                    : moduleStatus === 'in_progress'
+                      ? '#3b82f6'
+                      : '#22c55e',
+              },
+            ]}
+          />
+        </View>
 
-      <View style={styles.footer}>
-        <Text style={styles.lessonsText}>
-          {lessonsCompleted}/{totalLessons} lecciones
-        </Text>
-        <Text style={styles.progressText}>{progressPercent}%</Text>
-      </View>
-
-      <View style={styles.progressTrack}>
-        <View style={[styles.progressBar, { width: `${progressPercent}%` }]} />
-      </View>
-
-      <Pressable style={styles.actionButton} onPress={handlePress}>
-        <Text style={styles.actionText}>
-          {isComplete ? 'Revisar' : lessonsCompleted > 0 ? 'Continuar' : 'Comenzar'}
-        </Text>
-        <Icon icon={ChevronRight} size="sm" variant="primary" />
+        {/* Action button */}
+        <Pressable
+          style={[styles.actionButton, moduleStatus === 'locked' && styles.actionButtonLocked]}
+          onPress={handlePress}
+          disabled={moduleStatus === 'locked'}
+        >
+          <Text style={[styles.actionText, moduleStatus === 'locked' && styles.actionTextLocked]}>
+            {getActionButtonText()}
+          </Text>
+          <Icon
+            icon={moduleStatus === 'locked' ? Lock : ChevronRight}
+            size="sm"
+            variant={moduleStatus === 'locked' ? 'muted' : 'primary'}
+          />
+        </Pressable>
       </Pressable>
-    </Pressable>
+    </Animated.View>
   );
 }
 
@@ -74,11 +242,20 @@ const styles = StyleSheet.create({
   card: {
     flex: 1,
     minWidth: 280,
-    backgroundColor: '#1e293b',
     borderRadius: 16,
     padding: 20,
-    borderWidth: 1,
-    borderColor: '#334155',
+    borderWidth: 2,
+    position: 'relative',
+    // Hover effects will be applied via web CSS
+  },
+  pulsingIndicator: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#3b82f6',
   },
   header: {
     flexDirection: 'row',
@@ -89,13 +266,22 @@ const styles = StyleSheet.create({
   iconContainer: {
     width: 56,
     height: 56,
-    borderRadius: 14,
+    borderRadius: 12,
     backgroundColor: '#334155',
     justifyContent: 'center',
     alignItems: 'center',
   },
   iconContainerComplete: {
     backgroundColor: '#166534',
+  },
+  iconContainerInProgress: {
+    backgroundColor: '#1e3a8a',
+  },
+  iconContainerLocked: {
+    backgroundColor: '#1e293b',
+  },
+  iconEmoji: {
+    fontSize: 28,
   },
   completeBadge: {
     position: 'absolute',
@@ -114,13 +300,27 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     marginBottom: 16,
   },
-  footer: {
+  metaInfo: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 8,
   },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
   lessonsText: {
+    fontSize: 13,
+    color: '#64748b',
+  },
+  timeEstimate: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  timeText: {
     fontSize: 13,
     color: '#64748b',
   },
@@ -138,7 +338,6 @@ const styles = StyleSheet.create({
   },
   progressBar: {
     height: '100%',
-    backgroundColor: '#22c55e',
     borderRadius: 3,
   },
   actionButton: {
@@ -147,9 +346,15 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     gap: 4,
   },
+  actionButtonLocked: {
+    opacity: 0.5,
+  },
   actionText: {
     fontSize: 14,
     fontWeight: '600',
     color: '#3b82f6',
+  },
+  actionTextLocked: {
+    color: '#64748b',
   },
 });

--- a/apps/web/src/components/molecules/XPBar.tsx
+++ b/apps/web/src/components/molecules/XPBar.tsx
@@ -1,0 +1,213 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { useEffect } from 'react';
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
+
+export interface Level {
+  level: number;
+  name: string;
+  icon: string;
+  color: string;
+  minXP: number;
+}
+
+export interface XPBarProps {
+  currentXP: number;
+  currentLevel: Level;
+  nextLevel: Level | null;
+  xpProgress: number; // 0-100 percentage
+  size?: 'sm' | 'md' | 'lg';
+  showDetails?: boolean;
+}
+
+const SIZE_CONFIG = {
+  sm: {
+    barHeight: 8,
+    iconSize: 24,
+    fontSize: {
+      title: 14,
+      detail: 11,
+    },
+  },
+  md: {
+    barHeight: 12,
+    iconSize: 32,
+    fontSize: {
+      title: 16,
+      detail: 12,
+    },
+  },
+  lg: {
+    barHeight: 16,
+    iconSize: 40,
+    fontSize: {
+      title: 18,
+      detail: 14,
+    },
+  },
+};
+
+export function XPBar({
+  currentXP,
+  currentLevel,
+  nextLevel,
+  xpProgress,
+  size = 'md',
+  showDetails = true,
+}: XPBarProps) {
+  const config = SIZE_CONFIG[size];
+
+  // Animated progress bar
+  const progressWidth = useSharedValue(0);
+  const dotPosition = useSharedValue(0);
+
+  useEffect(() => {
+    progressWidth.value = withSpring(xpProgress, {
+      damping: 15,
+      stiffness: 100,
+    });
+    dotPosition.value = withSpring(xpProgress, {
+      damping: 15,
+      stiffness: 100,
+    });
+  }, [xpProgress, progressWidth, dotPosition]);
+
+  const animatedProgressStyle = useAnimatedStyle(() => ({
+    width: `${progressWidth.value}%`,
+  }));
+
+  const animatedDotStyle = useAnimatedStyle(() => ({
+    left: `${dotPosition.value}%`,
+  }));
+
+  const xpToNextLevel = nextLevel ? nextLevel.minXP - currentXP : 0;
+
+  return (
+    <View style={styles.container}>
+      {/* Header */}
+      {showDetails && (
+        <View style={styles.header}>
+          <View style={styles.levelInfo}>
+            <Text style={[styles.icon, { fontSize: config.iconSize }]}>{currentLevel.icon}</Text>
+            <View style={styles.levelText}>
+              <Text style={[styles.levelName, { fontSize: config.fontSize.title }]}>
+                {currentLevel.name}
+              </Text>
+              <Text style={[styles.levelNumber, { fontSize: config.fontSize.detail }]}>
+                Level {currentLevel.level}
+              </Text>
+            </View>
+          </View>
+        </View>
+      )}
+
+      {/* Progress Bar */}
+      <View style={[styles.progressBarContainer, { height: config.barHeight }]}>
+        <Animated.View style={[styles.progressBar, animatedProgressStyle]} />
+
+        {/* Floating Dot Indicator */}
+        {xpProgress > 0 && xpProgress < 100 && (
+          <Animated.View
+            style={[
+              styles.progressDot,
+              animatedDotStyle,
+              {
+                width: config.barHeight * 1.5,
+                height: config.barHeight * 1.5,
+                marginTop: -(config.barHeight * 0.25),
+                marginLeft: -(config.barHeight * 0.75),
+              },
+            ]}
+          />
+        )}
+      </View>
+
+      {/* Footer */}
+      {showDetails && nextLevel && (
+        <View style={styles.footer}>
+          <Text style={[styles.xpRemaining, { fontSize: config.fontSize.detail }]}>
+            {xpToNextLevel.toLocaleString()} XP to {nextLevel.name}
+          </Text>
+          <Text style={[styles.xpProgress, { fontSize: config.fontSize.detail }]}>
+            {Math.round(xpProgress)}%
+          </Text>
+        </View>
+      )}
+
+      {showDetails && !nextLevel && (
+        <View style={styles.footer}>
+          <Text style={[styles.xpRemaining, { fontSize: config.fontSize.detail }]}>
+            Max Level Reached!
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  levelInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  icon: {
+    marginRight: 8,
+  },
+  levelText: {
+    flexDirection: 'column',
+  },
+  levelName: {
+    fontWeight: '600',
+    color: '#F9FAFB',
+  },
+  levelNumber: {
+    color: '#9CA3AF',
+    marginTop: 2,
+  },
+  progressBarContainer: {
+    width: '100%',
+    backgroundColor: '#374151',
+    borderRadius: 9999,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  progressBar: {
+    height: '100%',
+    backgroundColor: '#3B82F6',
+    borderRadius: 9999,
+  },
+  progressDot: {
+    position: 'absolute',
+    top: 0,
+    backgroundColor: '#F9FAFB',
+    borderRadius: 9999,
+    borderWidth: 2,
+    borderColor: '#8B5CF6',
+    shadowColor: '#8B5CF6',
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.6,
+    shadowRadius: 6,
+    elevation: 8,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 6,
+  },
+  xpRemaining: {
+    color: '#9CA3AF',
+  },
+  xpProgress: {
+    color: '#9CA3AF',
+    fontWeight: '600',
+  },
+});

--- a/apps/web/src/components/molecules/__tests__/BadgeGrid.test.tsx
+++ b/apps/web/src/components/molecules/__tests__/BadgeGrid.test.tsx
@@ -1,0 +1,449 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { BadgeGrid, Badge, BadgeGridProps } from '../BadgeGrid';
+
+describe('BadgeGrid', () => {
+  const mockBadges: Badge[] = [
+    {
+      id: '1',
+      name: 'First Steps',
+      description: 'Complete your first lesson',
+      icon: '🎯',
+      unlockedAt: new Date('2024-01-01'),
+    },
+    {
+      id: '2',
+      name: 'Quick Learner',
+      description: 'Complete 5 lessons',
+      icon: '⚡',
+    },
+    {
+      id: '3',
+      name: 'Dedicated',
+      description: 'Maintain a 7-day streak',
+      icon: '🔥',
+      unlockedAt: new Date('2024-01-05'),
+    },
+    {
+      id: '4',
+      name: 'Expert',
+      description: 'Complete all modules',
+      icon: '🏆',
+    },
+  ];
+
+  const defaultProps: BadgeGridProps = {
+    badges: mockBadges,
+    unlockedBadgeIds: ['1', '3'],
+  };
+
+  describe('Rendering', () => {
+    it('should render all badges', () => {
+      const { getByText } = render(<BadgeGrid {...defaultProps} />);
+
+      expect(getByText('First Steps')).toBeTruthy();
+      expect(getByText('Quick Learner')).toBeTruthy();
+      expect(getByText('Dedicated')).toBeTruthy();
+      expect(getByText('Expert')).toBeTruthy();
+    });
+
+    it('should render badge icons', () => {
+      const { getByText } = render(<BadgeGrid {...defaultProps} />);
+
+      expect(getByText('🎯')).toBeTruthy();
+      expect(getByText('⚡')).toBeTruthy();
+      expect(getByText('🔥')).toBeTruthy();
+      expect(getByText('🏆')).toBeTruthy();
+    });
+
+    it('should render with empty badges array', () => {
+      const { queryByText } = render(<BadgeGrid badges={[]} unlockedBadgeIds={[]} />);
+
+      expect(queryByText('First Steps')).toBeNull();
+    });
+
+    it('should render single badge', () => {
+      const { getByText } = render(<BadgeGrid badges={[mockBadges[0]!]} unlockedBadgeIds={['1']} />);
+
+      expect(getByText('First Steps')).toBeTruthy();
+      expect(getByText('🎯')).toBeTruthy();
+    });
+
+    it('should render with testID for each badge', () => {
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} />);
+
+      expect(getByTestId('badge-1')).toBeTruthy();
+      expect(getByTestId('badge-2')).toBeTruthy();
+      expect(getByTestId('badge-3')).toBeTruthy();
+      expect(getByTestId('badge-4')).toBeTruthy();
+    });
+  });
+
+  describe('Unlocked State', () => {
+    it('should display unlocked badges with full opacity', () => {
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} />);
+
+      const unlockedBadge1 = getByTestId('badge-1');
+      const unlockedBadge3 = getByTestId('badge-3');
+
+      // Check that unlocked badges have the unlocked style
+      expect(unlockedBadge1.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 1 })])
+      );
+      expect(unlockedBadge3.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 1 })])
+      );
+    });
+
+    it('should display locked badges with reduced opacity', () => {
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} />);
+
+      const lockedBadge2 = getByTestId('badge-2');
+      const lockedBadge4 = getByTestId('badge-4');
+
+      // Check that locked badges have the locked style
+      expect(lockedBadge2.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 0.3 })])
+      );
+      expect(lockedBadge4.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 0.3 })])
+      );
+    });
+
+    it('should handle all badges unlocked', () => {
+      const { getByTestId } = render(
+        <BadgeGrid badges={mockBadges} unlockedBadgeIds={['1', '2', '3', '4']} />
+      );
+
+      ['1', '2', '3', '4'].forEach((id) => {
+        const badge = getByTestId(`badge-${id}`);
+        expect(badge.props.style).toEqual(
+          expect.arrayContaining([expect.objectContaining({ opacity: 1 })])
+        );
+      });
+    });
+
+    it('should handle all badges locked', () => {
+      const { getByTestId } = render(<BadgeGrid badges={mockBadges} unlockedBadgeIds={[]} />);
+
+      ['1', '2', '3', '4'].forEach((id) => {
+        const badge = getByTestId(`badge-${id}`);
+        expect(badge.props.style).toEqual(
+          expect.arrayContaining([expect.objectContaining({ opacity: 0.3 })])
+        );
+      });
+    });
+
+    it('should correctly identify unlocked badges', () => {
+      const { getByTestId } = render(
+        <BadgeGrid badges={mockBadges} unlockedBadgeIds={['2', '4']} />
+      );
+
+      // Badge 2 and 4 should be unlocked
+      const badge2 = getByTestId('badge-2');
+      const badge4 = getByTestId('badge-4');
+      expect(badge2.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 1 })])
+      );
+      expect(badge4.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 1 })])
+      );
+
+      // Badge 1 and 3 should be locked
+      const badge1 = getByTestId('badge-1');
+      const badge3 = getByTestId('badge-3');
+      expect(badge1.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 0.3 })])
+      );
+      expect(badge3.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 0.3 })])
+      );
+    });
+  });
+
+  describe('Badge Press Interaction', () => {
+    it('should call onBadgePress when badge is pressed', () => {
+      const onBadgePress = jest.fn();
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} onBadgePress={onBadgePress} />);
+
+      const badge1 = getByTestId('badge-1');
+      fireEvent.press(badge1);
+
+      expect(onBadgePress).toHaveBeenCalledTimes(1);
+      expect(onBadgePress).toHaveBeenCalledWith(mockBadges[0]!);
+    });
+
+    it('should call onBadgePress with correct badge data', () => {
+      const onBadgePress = jest.fn();
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} onBadgePress={onBadgePress} />);
+
+      const badge3 = getByTestId('badge-3');
+      fireEvent.press(badge3);
+
+      expect(onBadgePress).toHaveBeenCalledWith({
+        id: '3',
+        name: 'Dedicated',
+        description: 'Maintain a 7-day streak',
+        icon: '🔥',
+        unlockedAt: expect.any(Date),
+      });
+    });
+
+    it('should handle multiple badge presses', () => {
+      const onBadgePress = jest.fn();
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} onBadgePress={onBadgePress} />);
+
+      fireEvent.press(getByTestId('badge-1'));
+      fireEvent.press(getByTestId('badge-2'));
+      fireEvent.press(getByTestId('badge-3'));
+
+      expect(onBadgePress).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not call onBadgePress when not provided', () => {
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} />);
+
+      const badge1 = getByTestId('badge-1');
+      // Should not throw error when pressed without onBadgePress
+      expect(() => fireEvent.press(badge1)).not.toThrow();
+    });
+
+    it('should disable press when onBadgePress is not provided', () => {
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} />);
+
+      const badge1 = getByTestId('badge-1');
+      expect(badge1.props.accessibilityState?.disabled).toBe(true);
+    });
+
+    it('should enable press when onBadgePress is provided', () => {
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} onBadgePress={jest.fn()} />);
+
+      const badge1 = getByTestId('badge-1');
+      expect(badge1.props.accessibilityState?.disabled).toBe(false);
+    });
+
+    it('should allow pressing both locked and unlocked badges', () => {
+      const onBadgePress = jest.fn();
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} onBadgePress={onBadgePress} />);
+
+      // Press unlocked badge
+      fireEvent.press(getByTestId('badge-1'));
+      expect(onBadgePress).toHaveBeenCalledWith(mockBadges[0]!);
+
+      // Press locked badge
+      fireEvent.press(getByTestId('badge-2'));
+      expect(onBadgePress).toHaveBeenCalledWith(mockBadges[1]!);
+
+      expect(onBadgePress).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Badge Names', () => {
+    it('should truncate long badge names', () => {
+      const longNameBadges: Badge[] = [
+        {
+          id: '1',
+          name: 'This is a very long badge name that should be truncated',
+          description: 'Test description',
+          icon: '🎯',
+        },
+      ];
+
+      const { getByText } = render(<BadgeGrid badges={longNameBadges} unlockedBadgeIds={[]} />);
+
+      const badgeName = getByText('This is a very long badge name that should be truncated');
+      expect(badgeName.props.numberOfLines).toBe(2);
+    });
+
+    it('should render short badge names', () => {
+      const shortNameBadges: Badge[] = [
+        {
+          id: '1',
+          name: 'Pro',
+          description: 'Test',
+          icon: '⭐',
+        },
+      ];
+
+      const { getByText } = render(<BadgeGrid badges={shortNameBadges} unlockedBadgeIds={['1']} />);
+
+      expect(getByText('Pro')).toBeTruthy();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle badges with missing unlockedAt date', () => {
+      const { getByText } = render(<BadgeGrid {...defaultProps} />);
+
+      expect(getByText('Quick Learner')).toBeTruthy();
+      expect(getByText('Expert')).toBeTruthy();
+    });
+
+    it('should handle empty unlockedBadgeIds array', () => {
+      const { getByTestId } = render(<BadgeGrid badges={mockBadges} unlockedBadgeIds={[]} />);
+
+      mockBadges.forEach((badge) => {
+        const badgeElement = getByTestId(`badge-${badge.id}`);
+        expect(badgeElement.props.style).toEqual(
+          expect.arrayContaining([expect.objectContaining({ opacity: 0.3 })])
+        );
+      });
+    });
+
+    it('should handle duplicate badge IDs in unlockedBadgeIds', () => {
+      const { getByTestId } = render(
+        <BadgeGrid badges={mockBadges} unlockedBadgeIds={['1', '1', '1']} />
+      );
+
+      const badge1 = getByTestId('badge-1');
+      expect(badge1.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 1 })])
+      );
+    });
+
+    it('should handle unlockedBadgeIds that do not match any badge', () => {
+      const { getByTestId } = render(
+        <BadgeGrid badges={mockBadges} unlockedBadgeIds={['999', '1000']} />
+      );
+
+      // All badges should be locked
+      mockBadges.forEach((badge) => {
+        const badgeElement = getByTestId(`badge-${badge.id}`);
+        expect(badgeElement.props.style).toEqual(
+          expect.arrayContaining([expect.objectContaining({ opacity: 0.3 })])
+        );
+      });
+    });
+
+    it('should handle badges with special characters in names', () => {
+      const specialBadges: Badge[] = [
+        {
+          id: '1',
+          name: 'Badge & More!',
+          description: 'Special chars',
+          icon: '🎉',
+        },
+        {
+          id: '2',
+          name: 'Badge "Quotes"',
+          description: 'With quotes',
+          icon: '✨',
+        },
+      ];
+
+      const { getByText } = render(
+        <BadgeGrid badges={specialBadges} unlockedBadgeIds={['1', '2']} />
+      );
+
+      expect(getByText('Badge & More!')).toBeTruthy();
+      expect(getByText('Badge "Quotes"')).toBeTruthy();
+    });
+
+    it('should handle unicode emojis in icon field', () => {
+      const emojiBadges: Badge[] = [
+        { id: '1', name: 'Fire', description: 'Hot', icon: '🔥' },
+        { id: '2', name: 'Star', description: 'Bright', icon: '⭐' },
+        { id: '3', name: 'Heart', description: 'Love', icon: '❤️' },
+      ];
+
+      const { getByText } = render(
+        <BadgeGrid badges={emojiBadges} unlockedBadgeIds={['1', '2', '3']} />
+      );
+
+      expect(getByText('🔥')).toBeTruthy();
+      expect(getByText('⭐')).toBeTruthy();
+      expect(getByText('❤️')).toBeTruthy();
+    });
+  });
+
+  describe('Grid Layout', () => {
+    it('should render all badges in a grid layout', () => {
+      const { getByTestId } = render(<BadgeGrid {...defaultProps} />);
+
+      // All badges should be rendered
+      expect(getByTestId('badge-1')).toBeTruthy();
+      expect(getByTestId('badge-2')).toBeTruthy();
+      expect(getByTestId('badge-3')).toBeTruthy();
+      expect(getByTestId('badge-4')).toBeTruthy();
+    });
+
+    it('should handle large number of badges', () => {
+      const manyBadges: Badge[] = Array.from({ length: 20 }, (_, i) => ({
+        id: `${i + 1}`,
+        name: `Badge ${i + 1}`,
+        description: `Description ${i + 1}`,
+        icon: '🎯',
+      }));
+
+      const { getByTestId } = render(
+        <BadgeGrid badges={manyBadges} unlockedBadgeIds={['1', '5', '10']} />
+      );
+
+      // Check first and last badges are rendered
+      expect(getByTestId('badge-1')).toBeTruthy();
+      expect(getByTestId('badge-20')).toBeTruthy();
+    });
+
+    it('should handle odd number of badges', () => {
+      const oddBadges = mockBadges.slice(0, 3);
+      const { getByTestId } = render(<BadgeGrid badges={oddBadges} unlockedBadgeIds={['1']} />);
+
+      expect(getByTestId('badge-1')).toBeTruthy();
+      expect(getByTestId('badge-2')).toBeTruthy();
+      expect(getByTestId('badge-3')).toBeTruthy();
+    });
+  });
+
+  describe('Props Update', () => {
+    it('should update when badges change', () => {
+      const { getByText, rerender, queryByText } = render(
+        <BadgeGrid badges={[mockBadges[0]!]} unlockedBadgeIds={['1']} />
+      );
+
+      expect(getByText('First Steps')).toBeTruthy();
+      expect(queryByText('Quick Learner')).toBeNull();
+
+      rerender(<BadgeGrid badges={mockBadges} unlockedBadgeIds={['1', '2']} />);
+
+      expect(getByText('First Steps')).toBeTruthy();
+      expect(getByText('Quick Learner')).toBeTruthy();
+    });
+
+    it('should update when unlockedBadgeIds change', () => {
+      const { getByTestId, rerender } = render(
+        <BadgeGrid badges={mockBadges} unlockedBadgeIds={['1']} />
+      );
+
+      let badge2 = getByTestId('badge-2');
+      expect(badge2.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 0.3 })])
+      );
+
+      rerender(<BadgeGrid badges={mockBadges} unlockedBadgeIds={['1', '2']} />);
+
+      badge2 = getByTestId('badge-2');
+      expect(badge2.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 1 })])
+      );
+    });
+
+    it('should update onBadgePress callback', () => {
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+
+      const { getByTestId, rerender } = render(
+        <BadgeGrid {...defaultProps} onBadgePress={firstCallback} />
+      );
+
+      fireEvent.press(getByTestId('badge-1'));
+      expect(firstCallback).toHaveBeenCalledTimes(1);
+      expect(secondCallback).not.toHaveBeenCalled();
+
+      rerender(<BadgeGrid {...defaultProps} onBadgePress={secondCallback} />);
+
+      fireEvent.press(getByTestId('badge-1'));
+      expect(firstCallback).toHaveBeenCalledTimes(1);
+      expect(secondCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/components/molecules/__tests__/LevelBadge.test.tsx
+++ b/apps/web/src/components/molecules/__tests__/LevelBadge.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { LevelBadge, type Level } from '../LevelBadge';
+import { Trophy, Star, Zap } from 'lucide-react-native';
+
+// Mock lucide-react-native icons
+jest.mock('lucide-react-native', () => ({
+  Trophy: ({ size, color, strokeWidth }: any) => {
+    const { View, Text } = require('react-native');
+    return (
+      <View testID="mock-trophy-icon">
+        <Text testID="icon-size">{size}</Text>
+        <Text testID="icon-color">{color}</Text>
+        <Text testID="icon-stroke">{strokeWidth}</Text>
+      </View>
+    );
+  },
+  Star: ({ size, color, strokeWidth }: any) => {
+    const { View, Text } = require('react-native');
+    return (
+      <View testID="mock-star-icon">
+        <Text testID="icon-size">{size}</Text>
+        <Text testID="icon-color">{color}</Text>
+        <Text testID="icon-stroke">{strokeWidth}</Text>
+      </View>
+    );
+  },
+  Zap: ({ size, color, strokeWidth }: any) => {
+    const { View, Text } = require('react-native');
+    return (
+      <View testID="mock-zap-icon">
+        <Text testID="icon-size">{size}</Text>
+        <Text testID="icon-color">{color}</Text>
+        <Text testID="icon-stroke">{strokeWidth}</Text>
+      </View>
+    );
+  },
+}));
+
+describe('LevelBadge', () => {
+  const mockLevel: Level = {
+    level: 5,
+    icon: Trophy,
+    color: '#3B82F6',
+  };
+
+  describe('default variant', () => {
+    it('renders with default props', () => {
+      const { getByText } = render(<LevelBadge level={mockLevel} />);
+
+      expect(getByText('Lvl 5')).toBeTruthy();
+    });
+
+    it('displays level number with "Lvl" prefix', () => {
+      const { getByText } = render(<LevelBadge level={mockLevel} variant="default" />);
+
+      expect(getByText('Lvl 5')).toBeTruthy();
+    });
+
+    it('renders icon with correct color', () => {
+      const { getByTestId } = render(<LevelBadge level={mockLevel} variant="default" />);
+
+      const iconColor = getByTestId('icon-color');
+      expect(iconColor.props.children).toBe('#3B82F6');
+    });
+
+    it('applies correct size for small variant', () => {
+      const { getByTestId } = render(<LevelBadge level={mockLevel} size="sm" />);
+
+      const iconSize = getByTestId('icon-size');
+      expect(iconSize.props.children).toBe(16);
+    });
+
+    it('applies correct size for medium variant', () => {
+      const { getByTestId } = render(<LevelBadge level={mockLevel} size="md" />);
+
+      const iconSize = getByTestId('icon-size');
+      expect(iconSize.props.children).toBe(20);
+    });
+
+    it('applies correct size for large variant', () => {
+      const { getByTestId } = render(<LevelBadge level={mockLevel} size="lg" />);
+
+      const iconSize = getByTestId('icon-size');
+      expect(iconSize.props.children).toBe(24);
+    });
+  });
+
+  describe('minimal variant', () => {
+    it('renders with minimal variant', () => {
+      const { getByText } = render(<LevelBadge level={mockLevel} variant="minimal" />);
+
+      expect(getByText('5')).toBeTruthy();
+    });
+
+    it('displays only level number without "Lvl" prefix', () => {
+      const { getByText, queryByText } = render(<LevelBadge level={mockLevel} variant="minimal" />);
+
+      expect(getByText('5')).toBeTruthy();
+      expect(queryByText('Lvl 5')).toBeNull();
+    });
+
+    it('renders icon with correct color in minimal variant', () => {
+      const { getByTestId } = render(<LevelBadge level={mockLevel} variant="minimal" />);
+
+      const iconColor = getByTestId('icon-color');
+      expect(iconColor.props.children).toBe('#3B82F6');
+    });
+
+    it('applies correct size for small minimal variant', () => {
+      const { getByTestId } = render(<LevelBadge level={mockLevel} variant="minimal" size="sm" />);
+
+      const iconSize = getByTestId('icon-size');
+      expect(iconSize.props.children).toBe(16);
+    });
+  });
+
+  describe('different level configurations', () => {
+    it('renders level 1 correctly', () => {
+      const level1: Level = {
+        level: 1,
+        icon: Star,
+        color: '#10B981',
+      };
+
+      const { getByText, getByTestId } = render(<LevelBadge level={level1} />);
+
+      expect(getByText('Lvl 1')).toBeTruthy();
+      const iconColor = getByTestId('icon-color');
+      expect(iconColor.props.children).toBe('#10B981');
+    });
+
+    it('renders level 10 correctly', () => {
+      const level10: Level = {
+        level: 10,
+        icon: Zap,
+        color: '#F59E0B',
+      };
+
+      const { getByText, getByTestId } = render(<LevelBadge level={level10} />);
+
+      expect(getByText('Lvl 10')).toBeTruthy();
+      const iconColor = getByTestId('icon-color');
+      expect(iconColor.props.children).toBe('#F59E0B');
+    });
+
+    it('handles different icons correctly', () => {
+      const levelWithZap: Level = {
+        level: 7,
+        icon: Zap,
+        color: '#8B5CF6',
+      };
+
+      const { getByTestId } = render(<LevelBadge level={levelWithZap} />);
+
+      expect(getByTestId('mock-zap-icon')).toBeTruthy();
+    });
+  });
+
+  describe('color handling', () => {
+    it('applies custom color to text and icon', () => {
+      const customColorLevel: Level = {
+        level: 3,
+        icon: Trophy,
+        color: '#EF4444',
+      };
+
+      const { getByTestId, getByText } = render(<LevelBadge level={customColorLevel} />);
+
+      const iconColor = getByTestId('icon-color');
+      expect(iconColor.props.children).toBe('#EF4444');
+
+      const levelText = getByText('Lvl 3');
+      expect(levelText.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ color: '#EF4444' })])
+      );
+    });
+  });
+
+  describe('accessibility', () => {
+    it('renders text content that can be read by screen readers', () => {
+      const { getByText } = render(<LevelBadge level={mockLevel} />);
+
+      const levelText = getByText('Lvl 5');
+      expect(levelText).toBeTruthy();
+    });
+
+    it('renders minimal variant text for screen readers', () => {
+      const { getByText } = render(<LevelBadge level={mockLevel} variant="minimal" />);
+
+      const levelText = getByText('5');
+      expect(levelText).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/components/molecules/__tests__/ModuleCard.test.tsx
+++ b/apps/web/src/components/molecules/__tests__/ModuleCard.test.tsx
@@ -14,6 +14,8 @@ jest.mock('lucide-react-native', () => ({
   CheckCircle2: 'CheckCircle2',
   BookOpen: 'BookOpen',
   ChevronRight: 'ChevronRight',
+  Lock: 'Lock',
+  Clock: 'Clock',
 }));
 
 // Mock Icon component
@@ -58,9 +60,7 @@ describe('ModuleCard', () => {
   });
 
   it('should show 0% when no lessons completed', () => {
-    const { getByText } = render(
-      <ModuleCard {...mockModuleProps} lessonsCompleted={0} />
-    );
+    const { getByText } = render(<ModuleCard {...mockModuleProps} lessonsCompleted={0} />);
 
     expect(getByText('0%')).toBeTruthy();
     expect(getByText('0/10 lecciones')).toBeTruthy();
@@ -103,25 +103,19 @@ describe('ModuleCard', () => {
   });
 
   it('should show "Comenzar" button text when no lessons completed', () => {
-    const { getByText } = render(
-      <ModuleCard {...mockModuleProps} lessonsCompleted={0} />
-    );
+    const { getByText } = render(<ModuleCard {...mockModuleProps} lessonsCompleted={0} />);
 
     expect(getByText('Comenzar')).toBeTruthy();
   });
 
   it('should show "Continuar" button text when some lessons completed', () => {
-    const { getByText } = render(
-      <ModuleCard {...mockModuleProps} lessonsCompleted={5} />
-    );
+    const { getByText } = render(<ModuleCard {...mockModuleProps} lessonsCompleted={5} />);
 
     expect(getByText('Continuar')).toBeTruthy();
   });
 
   it('should show "Revisar" button text when module is complete', () => {
-    const { getByText } = render(
-      <ModuleCard {...mockModuleProps} isComplete={true} />
-    );
+    const { getByText } = render(<ModuleCard {...mockModuleProps} isComplete={true} />);
 
     expect(getByText('Revisar')).toBeTruthy();
   });
@@ -182,19 +176,17 @@ describe('ModuleCard', () => {
   });
 
   it('should handle long titles with truncation', () => {
-    const longTitle = 'This is a very long module title that should be truncated after two lines to prevent the card from becoming too wide and affecting the overall layout of the dashboard';
-    const { getByText } = render(
-      <ModuleCard {...mockModuleProps} title={longTitle} />
-    );
+    const longTitle =
+      'This is a very long module title that should be truncated after two lines to prevent the card from becoming too wide and affecting the overall layout of the dashboard';
+    const { getByText } = render(<ModuleCard {...mockModuleProps} title={longTitle} />);
 
     expect(getByText(longTitle)).toBeTruthy();
   });
 
   it('should handle long descriptions with truncation', () => {
-    const longDescription = 'This is a very long description that should be truncated after two lines to prevent the card from becoming too tall and affecting the overall layout. It contains many details about the module.';
-    const { getByText } = render(
-      <ModuleCard {...mockModuleProps} description={longDescription} />
-    );
+    const longDescription =
+      'This is a very long description that should be truncated after two lines to prevent the card from becoming too tall and affecting the overall layout. It contains many details about the module.';
+    const { getByText } = render(<ModuleCard {...mockModuleProps} description={longDescription} />);
 
     expect(getByText(longDescription)).toBeTruthy();
   });
@@ -209,9 +201,7 @@ describe('ModuleCard', () => {
   });
 
   it('should handle module with iconEmoji prop (even though not rendered)', () => {
-    const { getByText } = render(
-      <ModuleCard {...mockModuleProps} iconEmoji="🚀" />
-    );
+    const { getByText } = render(<ModuleCard {...mockModuleProps} iconEmoji="🚀" />);
 
     // Component should render normally, iconEmoji is accepted but not used
     expect(getByText('Introduction to Prompt Engineering')).toBeTruthy();
@@ -278,5 +268,70 @@ describe('ModuleCard', () => {
 
     expect(getByText('45/100 lecciones')).toBeTruthy();
     expect(getByText('45%')).toBeTruthy();
+  });
+
+  // New tests for locked state
+  it('should render locked module correctly', () => {
+    const { getByText, queryByText } = render(<ModuleCard {...mockModuleProps} isLocked={true} />);
+
+    expect(getByText('Bloqueado')).toBeTruthy();
+    expect(queryByText('Icon(Lock)')).toBeTruthy();
+  });
+
+  it('should not navigate when locked module is pressed', () => {
+    const { getByText } = render(<ModuleCard {...mockModuleProps} isLocked={true} />);
+
+    const card = getByText('Introduction to Prompt Engineering');
+    fireEvent.press(card.parent?.parent?.parent);
+
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it('should show "Bloqueado" for locked modules', () => {
+    const { getByText } = render(<ModuleCard {...mockModuleProps} status="locked" />);
+
+    expect(getByText('Bloqueado')).toBeTruthy();
+  });
+
+  it('should show in_progress status with correct styling', () => {
+    const { getByText } = render(<ModuleCard {...mockModuleProps} status="in_progress" />);
+
+    expect(getByText('Continuar')).toBeTruthy();
+  });
+
+  it('should display estimated time when provided', () => {
+    const { getByText } = render(<ModuleCard {...mockModuleProps} estimatedMinutes={45} />);
+
+    expect(getByText('45 min')).toBeTruthy();
+  });
+
+  it('should handle all module statuses', () => {
+    // Available status
+    const { getByText: getTextAvailable } = render(
+      <ModuleCard {...mockModuleProps} status="available" lessonsCompleted={0} />
+    );
+    expect(getTextAvailable('Comenzar')).toBeTruthy();
+
+    // In progress status
+    const { getByText: getTextInProgress } = render(
+      <ModuleCard {...mockModuleProps} status="in_progress" />
+    );
+    expect(getTextInProgress('Continuar')).toBeTruthy();
+
+    // Completed status
+    const { getByText: getTextCompleted } = render(
+      <ModuleCard {...mockModuleProps} status="completed" />
+    );
+    expect(getTextCompleted('Revisar')).toBeTruthy();
+
+    // Locked status
+    const { getByText: getTextLocked } = render(<ModuleCard {...mockModuleProps} status="locked" />);
+    expect(getTextLocked('Bloqueado')).toBeTruthy();
+  });
+
+  it('should display iconEmoji when provided', () => {
+    const { getByText } = render(<ModuleCard {...mockModuleProps} iconEmoji="🚀" />);
+
+    expect(getByText('🚀')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/molecules/__tests__/XPBar.test.tsx
+++ b/apps/web/src/components/molecules/__tests__/XPBar.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { XPBar, Level } from '../XPBar';
+
+const mockCurrentLevel: Level = {
+  level: 1,
+  name: 'Prompt Curious',
+  icon: '🌱',
+  color: '#3B82F6',
+  minXP: 0,
+};
+
+const mockNextLevel: Level = {
+  level: 2,
+  name: 'Prompt Apprentice',
+  icon: '🔰',
+  color: '#10B981',
+  minXP: 500,
+};
+
+describe('XPBar', () => {
+  it('should render correctly with basic props', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={250}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={50}
+      />
+    );
+
+    expect(getByText('Prompt Curious')).toBeTruthy();
+    expect(getByText('Level 1')).toBeTruthy();
+    expect(getByText('250 XP to Prompt Apprentice')).toBeTruthy();
+    expect(getByText('50%')).toBeTruthy();
+  });
+
+  it('should render without details when showDetails is false', () => {
+    const { queryByText } = render(
+      <XPBar
+        currentXP={250}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={50}
+        showDetails={false}
+      />
+    );
+
+    expect(queryByText('Prompt Curious')).toBeNull();
+    expect(queryByText('Level 1')).toBeNull();
+    expect(queryByText('250 XP to Prompt Apprentice')).toBeNull();
+  });
+
+  it('should show max level message when nextLevel is null', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={5000}
+        currentLevel={{
+          level: 10,
+          name: 'LLM Engineer',
+          icon: '🏆',
+          color: '#F59E0B',
+          minXP: 4500,
+        }}
+        nextLevel={null}
+        xpProgress={100}
+      />
+    );
+
+    expect(getByText('Max Level Reached!')).toBeTruthy();
+  });
+
+  it('should render with small size variant', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={100}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={20}
+        size="sm"
+      />
+    );
+
+    expect(getByText('Prompt Curious')).toBeTruthy();
+  });
+
+  it('should render with medium size variant (default)', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={250}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={50}
+      />
+    );
+
+    expect(getByText('Prompt Curious')).toBeTruthy();
+  });
+
+  it('should render with large size variant', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={400}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={80}
+        size="lg"
+      />
+    );
+
+    expect(getByText('Prompt Curious')).toBeTruthy();
+  });
+
+  it('should display level icon', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={250}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={50}
+      />
+    );
+
+    expect(getByText('🌱')).toBeTruthy();
+  });
+
+  it('should calculate XP remaining correctly', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={300}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={60}
+      />
+    );
+
+    expect(getByText('200 XP to Prompt Apprentice')).toBeTruthy();
+  });
+
+  it('should format large XP numbers with commas', () => {
+    const highLevel: Level = {
+      level: 10,
+      name: 'LLM Engineer',
+      icon: '🏆',
+      color: '#F59E0B',
+      minXP: 4500,
+    };
+
+    const nextHighLevel: Level = {
+      level: 11,
+      name: 'LLM Master',
+      icon: '👑',
+      color: '#8B5CF6',
+      minXP: 5500,
+    };
+
+    const { getByText } = render(
+      <XPBar currentXP={4750} currentLevel={highLevel} nextLevel={nextHighLevel} xpProgress={25} />
+    );
+
+    expect(getByText('750 XP to LLM Master')).toBeTruthy();
+  });
+
+  it('should display progress percentage rounded', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={333}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={66.6}
+      />
+    );
+
+    expect(getByText('67%')).toBeTruthy();
+  });
+
+  it('should handle 0% progress', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={0}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={0}
+      />
+    );
+
+    expect(getByText('0%')).toBeTruthy();
+    expect(getByText('500 XP to Prompt Apprentice')).toBeTruthy();
+  });
+
+  it('should handle 100% progress', () => {
+    const { getByText } = render(
+      <XPBar
+        currentXP={500}
+        currentLevel={mockCurrentLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={100}
+      />
+    );
+
+    expect(getByText('100%')).toBeTruthy();
+  });
+
+  it('should render level name correctly', () => {
+    const customLevel: Level = {
+      level: 5,
+      name: 'Embedding Explorer',
+      icon: '🧭',
+      color: '#6366F1',
+      minXP: 2000,
+    };
+
+    const { getByText } = render(
+      <XPBar
+        currentXP={2250}
+        currentLevel={customLevel}
+        nextLevel={mockNextLevel}
+        xpProgress={50}
+      />
+    );
+
+    expect(getByText('Embedding Explorer')).toBeTruthy();
+    expect(getByText('Level 5')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/molecules/index.ts
+++ b/apps/web/src/components/molecules/index.ts
@@ -1,5 +1,5 @@
 export { ProgressCard } from './ProgressCard';
-export { LessonCard } from './LessonCard';
+export { LessonCard, type LessonCardProps, type LessonStatus } from './LessonCard';
 export { StreakBanner } from './StreakBanner';
 export { DashboardHeader } from './DashboardHeader';
 export { QuickActionsGrid, type QuickAction } from './QuickActionsGrid';
@@ -7,4 +7,7 @@ export { NextLessonWidget } from './NextLessonWidget';
 export { LeaderboardWidget } from './LeaderboardWidget';
 export { StatsGrid } from './StatsGrid';
 export { GlobalProgress } from './GlobalProgress';
-export { ModuleCard } from './ModuleCard';
+export { ModuleCard, type ModuleCardProps, type ModuleStatus } from './ModuleCard';
+export { XPBar, type XPBarProps, type Level } from './XPBar';
+export { BadgeGrid, type Badge, type BadgeGridProps } from './BadgeGrid';
+export { LevelBadge, type LevelBadgeProps, type Level as LevelBadgeLevel } from './LevelBadge';

--- a/apps/web/src/components/ui/Animated.tsx
+++ b/apps/web/src/components/ui/Animated.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export type AnimationType = 'fadeIn' | 'slideUp' | 'scaleIn' | 'glow' | 'bounce' | 'pulse';
+
+export interface AnimatedProps {
+  children: React.ReactNode;
+  animation?: AnimationType;
+  delay?: number;
+  duration?: number;
+  className?: string;
+}
+
+const animationMap: Record<AnimationType, string> = {
+  fadeIn: 'fadeIn',
+  slideUp: 'slideUp',
+  scaleIn: 'scaleIn',
+  glow: 'glow',
+  bounce: 'bounceSubtle',
+  pulse: 'pulse',
+};
+
+export function Animated({
+  children,
+  animation = 'fadeIn',
+  delay = 0,
+  duration = 0.3,
+  className = '',
+}: AnimatedProps) {
+  const animationName = animationMap[animation];
+  const animationStyle = {
+    animationName,
+    animationDuration: `${duration}s`,
+    animationDelay: `${delay}s`,
+    animationFillMode: 'both' as const,
+    animationTimingFunction: 'ease-out' as const,
+  };
+
+  // For infinite animations
+  if (animation === 'glow' || animation === 'bounce' || animation === 'pulse') {
+    animationStyle.animationTimingFunction = 'ease-in-out';
+    Object.assign(animationStyle, {
+      animationIterationCount: 'infinite',
+    });
+  }
+
+  return (
+    <View style={animationStyle} className={className}>
+      {children}
+    </View>
+  );
+}

--- a/apps/web/src/components/ui/EmptyState.tsx
+++ b/apps/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import type { LucideIcon } from 'lucide-react-native';
+import { Icon } from './Icon';
+
+export interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  action?: {
+    label: string;
+    onPress: () => void;
+  };
+}
+
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <View className="flex-1 items-center justify-center px-6 py-12">
+      {/* Icon */}
+      {icon && (
+        <View className="mb-4 p-4 bg-gray-800 rounded-full">
+          <Icon icon={icon} size="xl" variant="muted" />
+        </View>
+      )}
+
+      {/* Title */}
+      <Text className="text-xl font-semibold text-gray-100 text-center mb-2">{title}</Text>
+
+      {/* Description */}
+      {description && (
+        <Text className="text-base text-gray-400 text-center mb-6 max-w-sm">{description}</Text>
+      )}
+
+      {/* Action Button */}
+      {action && (
+        <Pressable
+          onPress={action.onPress}
+          className="bg-primary-600 hover:bg-primary-700 px-6 py-3 rounded-lg active:opacity-80"
+        >
+          <Text className="text-white font-semibold text-base">{action.label}</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}

--- a/apps/web/src/components/ui/Skeleton.tsx
+++ b/apps/web/src/components/ui/Skeleton.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ViewStyle } from 'react-native';
+
+export interface SkeletonProps {
+  variant?: 'text' | 'circular' | 'rectangular';
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+}
+
+export function Skeleton({
+  variant = 'rectangular',
+  width,
+  height,
+  className = '',
+}: SkeletonProps) {
+  const getVariantStyles = (): string => {
+    switch (variant) {
+      case 'text':
+        return 'h-4 rounded';
+      case 'circular':
+        return 'rounded-full';
+      case 'rectangular':
+      default:
+        return 'rounded-lg';
+    }
+  };
+
+  const getDimensions = (): ViewStyle => {
+    const style: ViewStyle = {};
+
+    if (width !== undefined) {
+      style.width = typeof width === 'number' ? width : width;
+    }
+
+    if (height !== undefined) {
+      style.height = typeof height === 'number' ? height : height;
+    }
+
+    // Default dimensions based on variant
+    if (variant === 'circular' && !width && !height) {
+      style.width = 40;
+      style.height = 40;
+    } else if (variant === 'text' && !height) {
+      style.height = 16;
+    } else if (variant === 'rectangular' && !height) {
+      style.height = 100;
+    }
+
+    return style;
+  };
+
+  return (
+    <View
+      style={getDimensions()}
+      className={`bg-gray-700 animate-shimmer overflow-hidden ${getVariantStyles()} ${className}`}
+    />
+  );
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,1 +1,4 @@
 export { Icon, type IconProps, type IconSize, type IconVariant } from './Icon';
+export { Animated, type AnimatedProps, type AnimationType } from './Animated';
+export { Skeleton, type SkeletonProps } from './Skeleton';
+export { EmptyState, type EmptyStateProps } from './EmptyState';


### PR DESCRIPTION
## Summary
- **UI-011**: Enhanced ModuleCard/LessonCard with locked/in_progress/completed visual states and animations (#107)
- **UI-012**: XPBar component with animated progress bar, size variants, and level milestones (#108)
- **UI-013**: LevelBadge component with default/minimal variants and size options (#109)
- **UI-014**: BadgeGrid component with locked/unlocked badge states and responsive grid (#110)
- **UI-015**: Animations system with CSS keyframes (fadeIn, slideUp, pulse, glow) and Animated wrapper component (#111)
- **UI-016**: Skeleton loading component, EmptyState component, custom scrollbar styles, focus states, text gradients (#112)

## Components Created
| Component | Description |
|-----------|-------------|
| `XPBar.tsx` | XP progress bar with animated fill, level milestones, and size variants |
| `LevelBadge.tsx` | Level display badge with default/minimal variants |
| `BadgeGrid.tsx` | Badge collection grid with locked/unlocked states |
| `Animated.tsx` | Animation wrapper component with preset animations |
| `Skeleton.tsx` | Loading skeleton placeholder component |
| `EmptyState.tsx` | Empty state display with icon, title, description |

## Enhancements
- **ModuleCard.tsx**: Added status states (locked/available/in_progress/completed), pulsing animation for in-progress, press animations
- **LessonCard.tsx**: Added status states, visual indicators, press animations
- **global.css**: Added animation keyframes, custom scrollbar styles, focus states, text gradients

## Test Coverage
- 45+ tests covering all new and enhanced components
- Tests for all visual states and interactions

## Test plan
- [ ] Verify XPBar renders with different progress values
- [ ] Verify LevelBadge displays correctly in both variants
- [ ] Verify BadgeGrid shows locked/unlocked states correctly
- [ ] Verify animations work in browser
- [ ] Verify ModuleCard/LessonCard status states render correctly
- [ ] Verify press interactions work on cards
- [ ] Run tests: `npm run test -w @llmengineer/web`

Closes #107, #108, #109, #110, #111, #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)