### PR TITLE
Release: Game scores API and edit profile modal

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -13,6 +13,8 @@ model User {
   email        String   @unique
   password     String
   displayName  String
+  avatarUrl    String?
+  bio          String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
@@ -20,6 +22,7 @@ model User {
   completions  LessonCompletion[]
   badges       UserBadge[]
   streakLog    StreakLog[]
+  gameScores   GameScore[]
 
   @@map("users")
 }
@@ -154,4 +157,20 @@ model LeaderboardSnapshot {
 enum LeaderboardSnapshotType {
   GLOBAL
   WEEKLY
+}
+
+model GameScore {
+  id        String   @id @default(cuid())
+  userId    String
+  gameType  String   // e.g., "embedding-match", "token-tetris", "prompt-golf"
+  score     Int
+  level     Int?     // Optional: some games have levels
+  metadata  Json?    // Optional: additional game-specific data (timeRemaining, matches, etc.)
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([gameType, score])
+  @@index([userId, gameType])
+  @@map("game_scores")
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { StreaksModule } from './streaks/streaks.module';
 import { QuizModule } from './quiz/quiz.module';
 import { HealthModule } from './health/health.module';
 import { EmbeddingMatchModule } from './games/embedding-match/embedding-match.module';
+import { ScoresModule } from './games/scores/scores.module';
 import { CustomThrottlerGuard } from './common/guards/custom-throttler.guard';
 
 @Module({
@@ -35,6 +36,7 @@ import { CustomThrottlerGuard } from './common/guards/custom-throttler.guard';
     QuizModule,
     HealthModule,
     EmbeddingMatchModule,
+    ScoresModule,
   ],
   providers: [
     {

--- a/apps/api/src/games/scores/dto/game-score-response.dto.ts
+++ b/apps/api/src/games/scores/dto/game-score-response.dto.ts
@@ -1,0 +1,167 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GameScoreResponseDto {
+  @ApiProperty({
+    example: 'cuid123',
+    description: 'Score ID',
+  })
+  id: string;
+
+  @ApiProperty({
+    example: 'user123',
+    description: 'User ID',
+  })
+  userId: string;
+
+  @ApiProperty({
+    example: 'John Doe',
+    description: 'User display name',
+  })
+  displayName: string;
+
+  @ApiProperty({
+    example: 'embedding-match',
+    description: 'Game type',
+  })
+  gameType: string;
+
+  @ApiProperty({
+    example: 850,
+    description: 'Score achieved',
+  })
+  score: number;
+
+  @ApiPropertyOptional({
+    example: 1,
+    description: 'Level number',
+  })
+  level?: number;
+
+  @ApiPropertyOptional({
+    example: { timeRemaining: 45, matches: 8 },
+    description: 'Additional metadata',
+  })
+  metadata?: Record<string, unknown>;
+
+  @ApiProperty({
+    example: '2025-12-13T10:30:00.000Z',
+    description: 'Timestamp when score was created',
+  })
+  createdAt: Date;
+}
+
+export class LeaderboardScoreDto {
+  @ApiProperty({
+    example: 1,
+    description: 'Rank on leaderboard',
+  })
+  rank: number;
+
+  @ApiProperty({
+    example: 'user123',
+    description: 'User ID',
+  })
+  userId: string;
+
+  @ApiProperty({
+    example: 'John Doe',
+    description: 'User display name',
+  })
+  displayName: string;
+
+  @ApiProperty({
+    example: 850,
+    description: 'Score achieved',
+  })
+  score: number;
+
+  @ApiPropertyOptional({
+    example: 1,
+    description: 'Level number',
+  })
+  level?: number;
+
+  @ApiProperty({
+    example: '2025-12-13T10:30:00.000Z',
+    description: 'Timestamp when score was created',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: false,
+    description: 'Whether this is the current user',
+  })
+  isCurrentUser: boolean;
+}
+
+export class GameLeaderboardResponseDto {
+  @ApiProperty({
+    example: 'embedding-match',
+    description: 'Game type',
+  })
+  gameType: string;
+
+  @ApiProperty({
+    type: [LeaderboardScoreDto],
+    description: 'Top scores for this game',
+  })
+  scores: LeaderboardScoreDto[];
+
+  @ApiProperty({
+    example: 100,
+    description: 'Total number of scores',
+  })
+  total: number;
+
+  @ApiProperty({
+    example: 0,
+    description: 'Offset for pagination',
+  })
+  offset: number;
+
+  @ApiProperty({
+    example: 50,
+    description: 'Limit for pagination',
+  })
+  limit: number;
+}
+
+export class PersonalBestDto {
+  @ApiProperty({
+    example: 'embedding-match',
+    description: 'Game type',
+  })
+  gameType: string;
+
+  @ApiProperty({
+    example: 850,
+    description: 'Best score achieved',
+  })
+  bestScore: number;
+
+  @ApiPropertyOptional({
+    example: 1,
+    description: 'Level for best score',
+  })
+  level?: number;
+
+  @ApiProperty({
+    example: '2025-12-13T10:30:00.000Z',
+    description: 'When best score was achieved',
+  })
+  achievedAt: Date;
+
+  @ApiProperty({
+    example: 15,
+    description: 'Total number of attempts',
+  })
+  totalAttempts: number;
+}
+
+export class UserPersonalBestsResponseDto {
+  @ApiProperty({
+    type: [PersonalBestDto],
+    description: 'Personal best scores for each game type',
+  })
+  personalBests: PersonalBestDto[];
+}

--- a/apps/api/src/games/scores/dto/get-leaderboard.dto.ts
+++ b/apps/api/src/games/scores/dto/get-leaderboard.dto.ts
@@ -1,0 +1,38 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetLeaderboardQueryDto {
+  @ApiPropertyOptional({
+    example: 50,
+    description: 'Maximum number of scores to return',
+    default: 50,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 50;
+
+  @ApiPropertyOptional({
+    example: 0,
+    description: 'Number of scores to skip for pagination',
+    default: 0,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+
+  @ApiPropertyOptional({
+    example: 1,
+    description: 'Filter by level number',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  level?: number;
+}

--- a/apps/api/src/games/scores/dto/index.ts
+++ b/apps/api/src/games/scores/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './submit-game-score.dto';
+export * from './game-score-response.dto';
+export * from './get-leaderboard.dto';

--- a/apps/api/src/games/scores/dto/submit-game-score.dto.ts
+++ b/apps/api/src/games/scores/dto/submit-game-score.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsInt, Min, IsOptional, IsObject } from 'class-validator';
+
+export class SubmitGameScoreDto {
+  @ApiProperty({
+    example: 'embedding-match',
+    description: 'Type of game (embedding-match, token-tetris, prompt-golf)',
+  })
+  @IsString()
+  gameType: string;
+
+  @ApiProperty({
+    example: 850,
+    description: 'Score achieved in the game',
+  })
+  @IsInt()
+  @Min(0)
+  score: number;
+
+  @ApiPropertyOptional({
+    example: 1,
+    description: 'Level number (optional, for games with levels)',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  level?: number;
+
+  @ApiPropertyOptional({
+    example: { timeRemaining: 45, matches: 8 },
+    description: 'Additional metadata (optional)',
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/apps/api/src/games/scores/scores.controller.spec.ts
+++ b/apps/api/src/games/scores/scores.controller.spec.ts
@@ -1,0 +1,493 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ScoresController } from './scores.controller';
+import { ScoresService } from './scores.service';
+import {
+  GameScoreResponseDto,
+  GameLeaderboardResponseDto,
+  UserPersonalBestsResponseDto,
+} from './dto';
+
+describe('ScoresController', () => {
+  let controller: ScoresController;
+
+  const mockScoresService = {
+    submitScore: jest.fn(),
+    getLeaderboardByUniqueUsers: jest.fn(),
+    getUserPersonalBests: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ScoresController],
+      providers: [
+        {
+          provide: ScoresService,
+          useValue: mockScoresService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ScoresController>(ScoresController);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('submitScore', () => {
+    it('should submit a score successfully', async () => {
+      const user = { userId: 'user123' };
+      const dto = {
+        gameType: 'embedding-match',
+        score: 850,
+        level: 1,
+        metadata: { timeRemaining: 45 },
+      };
+
+      const expectedResult: GameScoreResponseDto = {
+        id: 'score123',
+        userId: user.userId,
+        displayName: 'John Doe',
+        gameType: dto.gameType,
+        score: dto.score,
+        level: dto.level,
+        metadata: dto.metadata,
+        createdAt: new Date(),
+      };
+
+      mockScoresService.submitScore.mockResolvedValue(expectedResult);
+
+      const result = await controller.submitScore(user, dto);
+
+      expect(result).toEqual(expectedResult);
+      expect(mockScoresService.submitScore).toHaveBeenCalledWith(user.userId, dto);
+      expect(mockScoresService.submitScore).toHaveBeenCalledTimes(1);
+    });
+
+    it('should submit score without optional fields', async () => {
+      const user = { userId: 'user456' };
+      const dto = {
+        gameType: 'token-tetris',
+        score: 1200,
+      };
+
+      const expectedResult: GameScoreResponseDto = {
+        id: 'score456',
+        userId: user.userId,
+        displayName: 'Jane Doe',
+        gameType: dto.gameType,
+        score: dto.score,
+        createdAt: new Date(),
+      };
+
+      mockScoresService.submitScore.mockResolvedValue(expectedResult);
+
+      const result = await controller.submitScore(user, dto);
+
+      expect(result).toEqual(expectedResult);
+      expect(mockScoresService.submitScore).toHaveBeenCalledWith(user.userId, dto);
+    });
+
+    it('should handle multiple score submissions', async () => {
+      const user = { userId: 'user123' };
+      const dto1 = { gameType: 'embedding-match', score: 850 };
+      const dto2 = { gameType: 'embedding-match', score: 900 };
+
+      const result1: GameScoreResponseDto = {
+        id: 'score1',
+        userId: user.userId,
+        displayName: 'John Doe',
+        gameType: dto1.gameType,
+        score: dto1.score,
+        createdAt: new Date(),
+      };
+
+      const result2: GameScoreResponseDto = {
+        id: 'score2',
+        userId: user.userId,
+        displayName: 'John Doe',
+        gameType: dto2.gameType,
+        score: dto2.score,
+        createdAt: new Date(),
+      };
+
+      mockScoresService.submitScore.mockResolvedValueOnce(result1).mockResolvedValueOnce(result2);
+
+      const firstSubmit = await controller.submitScore(user, dto1);
+      const secondSubmit = await controller.submitScore(user, dto2);
+
+      expect(firstSubmit.score).toBe(850);
+      expect(secondSubmit.score).toBe(900);
+      expect(mockScoresService.submitScore).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getLeaderboard', () => {
+    it('should return leaderboard for a game type', async () => {
+      const user = { userId: 'user123' };
+      const gameType = 'embedding-match';
+      const query = { limit: 50, offset: 0 };
+
+      const expectedResult: GameLeaderboardResponseDto = {
+        gameType,
+        scores: [
+          {
+            rank: 1,
+            userId: 'user1',
+            displayName: 'User One',
+            score: 1000,
+            level: 1,
+            createdAt: new Date(),
+            isCurrentUser: false,
+          },
+          {
+            rank: 2,
+            userId: user.userId,
+            displayName: 'Current User',
+            score: 850,
+            level: 1,
+            createdAt: new Date(),
+            isCurrentUser: true,
+          },
+        ],
+        total: 2,
+        offset: 0,
+        limit: 50,
+      };
+
+      mockScoresService.getLeaderboardByUniqueUsers.mockResolvedValue(expectedResult);
+
+      const result = await controller.getLeaderboard(gameType, user, query);
+
+      expect(result).toEqual(expectedResult);
+      expect(mockScoresService.getLeaderboardByUniqueUsers).toHaveBeenCalledWith(
+        gameType,
+        user.userId,
+        query.limit,
+        query.offset,
+        undefined
+      );
+    });
+
+    it('should filter leaderboard by level', async () => {
+      const user = { userId: 'user123' };
+      const gameType = 'embedding-match';
+      const query = { limit: 50, offset: 0, level: 2 };
+
+      const expectedResult: GameLeaderboardResponseDto = {
+        gameType,
+        scores: [
+          {
+            rank: 1,
+            userId: 'user1',
+            displayName: 'User One',
+            score: 950,
+            level: 2,
+            createdAt: new Date(),
+            isCurrentUser: false,
+          },
+        ],
+        total: 1,
+        offset: 0,
+        limit: 50,
+      };
+
+      mockScoresService.getLeaderboardByUniqueUsers.mockResolvedValue(expectedResult);
+
+      const result = await controller.getLeaderboard(gameType, user, query);
+
+      expect(result).toEqual(expectedResult);
+      expect(mockScoresService.getLeaderboardByUniqueUsers).toHaveBeenCalledWith(
+        gameType,
+        user.userId,
+        query.limit,
+        query.offset,
+        query.level
+      );
+    });
+
+    it('should handle pagination parameters', async () => {
+      const user = { userId: 'user123' };
+      const gameType = 'embedding-match';
+      const query = { limit: 10, offset: 20 };
+
+      const expectedResult: GameLeaderboardResponseDto = {
+        gameType,
+        scores: [],
+        total: 100,
+        offset: 20,
+        limit: 10,
+      };
+
+      mockScoresService.getLeaderboardByUniqueUsers.mockResolvedValue(expectedResult);
+
+      const result = await controller.getLeaderboard(gameType, user, query);
+
+      expect(result.offset).toBe(20);
+      expect(result.limit).toBe(10);
+      expect(mockScoresService.getLeaderboardByUniqueUsers).toHaveBeenCalledWith(
+        gameType,
+        user.userId,
+        10,
+        20,
+        undefined
+      );
+    });
+
+    it('should handle different game types', async () => {
+      const user = { userId: 'user123' };
+      const gameTypes = ['embedding-match', 'token-tetris', 'prompt-golf'];
+      const query = { limit: 50, offset: 0 };
+
+      for (const gameType of gameTypes) {
+        const expectedResult: GameLeaderboardResponseDto = {
+          gameType,
+          scores: [],
+          total: 0,
+          offset: 0,
+          limit: 50,
+        };
+
+        mockScoresService.getLeaderboardByUniqueUsers.mockResolvedValue(expectedResult);
+
+        const result = await controller.getLeaderboard(gameType, user, query);
+
+        expect(result.gameType).toBe(gameType);
+        expect(mockScoresService.getLeaderboardByUniqueUsers).toHaveBeenCalledWith(
+          gameType,
+          user.userId,
+          query.limit,
+          query.offset,
+          undefined
+        );
+      }
+    });
+
+    it('should mark current user correctly', async () => {
+      const user = { userId: 'user123' };
+      const gameType = 'embedding-match';
+      const query = { limit: 50, offset: 0 };
+
+      const expectedResult: GameLeaderboardResponseDto = {
+        gameType,
+        scores: [
+          {
+            rank: 1,
+            userId: 'other-user',
+            displayName: 'Other User',
+            score: 1000,
+            createdAt: new Date(),
+            isCurrentUser: false,
+          },
+          {
+            rank: 2,
+            userId: user.userId,
+            displayName: 'Current User',
+            score: 850,
+            createdAt: new Date(),
+            isCurrentUser: true,
+          },
+        ],
+        total: 2,
+        offset: 0,
+        limit: 50,
+      };
+
+      mockScoresService.getLeaderboardByUniqueUsers.mockResolvedValue(expectedResult);
+
+      const result = await controller.getLeaderboard(gameType, user, query);
+
+      expect(result.scores[0].isCurrentUser).toBe(false);
+      expect(result.scores[1].isCurrentUser).toBe(true);
+    });
+  });
+
+  describe('getPersonalBests', () => {
+    it('should return personal bests for all games', async () => {
+      const user = { userId: 'user123' };
+
+      const expectedResult: UserPersonalBestsResponseDto = {
+        personalBests: [
+          {
+            gameType: 'embedding-match',
+            bestScore: 850,
+            level: 1,
+            achievedAt: new Date(),
+            totalAttempts: 10,
+          },
+          {
+            gameType: 'token-tetris',
+            bestScore: 1200,
+            achievedAt: new Date(),
+            totalAttempts: 5,
+          },
+        ],
+      };
+
+      mockScoresService.getUserPersonalBests.mockResolvedValue(expectedResult);
+
+      const result = await controller.getPersonalBests(user);
+
+      expect(result).toEqual(expectedResult);
+      expect(result.personalBests).toHaveLength(2);
+      expect(mockScoresService.getUserPersonalBests).toHaveBeenCalledWith(user.userId);
+    });
+
+    it('should return empty array if user has no scores', async () => {
+      const user = { userId: 'user123' };
+
+      const expectedResult: UserPersonalBestsResponseDto = {
+        personalBests: [],
+      };
+
+      mockScoresService.getUserPersonalBests.mockResolvedValue(expectedResult);
+
+      const result = await controller.getPersonalBests(user);
+
+      expect(result.personalBests).toEqual([]);
+      expect(mockScoresService.getUserPersonalBests).toHaveBeenCalledWith(user.userId);
+    });
+
+    it('should include all game statistics', async () => {
+      const user = { userId: 'user123' };
+
+      const expectedResult: UserPersonalBestsResponseDto = {
+        personalBests: [
+          {
+            gameType: 'embedding-match',
+            bestScore: 950,
+            level: 3,
+            achievedAt: new Date('2025-12-01'),
+            totalAttempts: 25,
+          },
+        ],
+      };
+
+      mockScoresService.getUserPersonalBests.mockResolvedValue(expectedResult);
+
+      const result = await controller.getPersonalBests(user);
+
+      expect(result.personalBests[0].bestScore).toBe(950);
+      expect(result.personalBests[0].level).toBe(3);
+      expect(result.personalBests[0].totalAttempts).toBe(25);
+      expect(result.personalBests[0].achievedAt).toEqual(new Date('2025-12-01'));
+    });
+
+    it('should handle multiple games with varying data', async () => {
+      const user = { userId: 'user123' };
+
+      const expectedResult: UserPersonalBestsResponseDto = {
+        personalBests: [
+          {
+            gameType: 'embedding-match',
+            bestScore: 850,
+            level: 1,
+            achievedAt: new Date(),
+            totalAttempts: 10,
+          },
+          {
+            gameType: 'token-tetris',
+            bestScore: 1200,
+            achievedAt: new Date(),
+            totalAttempts: 5,
+          },
+          {
+            gameType: 'prompt-golf',
+            bestScore: 42,
+            level: 5,
+            achievedAt: new Date(),
+            totalAttempts: 15,
+          },
+        ],
+      };
+
+      mockScoresService.getUserPersonalBests.mockResolvedValue(expectedResult);
+
+      const result = await controller.getPersonalBests(user);
+
+      expect(result.personalBests).toHaveLength(3);
+      expect(result.personalBests.every((pb) => pb.bestScore > 0)).toBe(true);
+      expect(result.personalBests.every((pb) => pb.totalAttempts > 0)).toBe(true);
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should handle complete user game flow', async () => {
+      const user = { userId: 'user123' };
+      const gameType = 'embedding-match';
+
+      // 1. Submit first score
+      const submitDto1 = { gameType, score: 750, level: 1 };
+      const scoreResult1: GameScoreResponseDto = {
+        id: 'score1',
+        userId: user.userId,
+        displayName: 'John Doe',
+        gameType,
+        score: 750,
+        level: 1,
+        createdAt: new Date(),
+      };
+      mockScoresService.submitScore.mockResolvedValueOnce(scoreResult1);
+
+      // 2. Submit improved score
+      const submitDto2 = { gameType, score: 900, level: 1 };
+      const scoreResult2: GameScoreResponseDto = {
+        id: 'score2',
+        userId: user.userId,
+        displayName: 'John Doe',
+        gameType,
+        score: 900,
+        level: 1,
+        createdAt: new Date(),
+      };
+      mockScoresService.submitScore.mockResolvedValueOnce(scoreResult2);
+
+      // 3. Check personal bests
+      const personalBestsResult: UserPersonalBestsResponseDto = {
+        personalBests: [
+          {
+            gameType,
+            bestScore: 900,
+            level: 1,
+            achievedAt: new Date(),
+            totalAttempts: 2,
+          },
+        ],
+      };
+      mockScoresService.getUserPersonalBests.mockResolvedValue(personalBestsResult);
+
+      // 4. Check leaderboard
+      const leaderboardResult: GameLeaderboardResponseDto = {
+        gameType,
+        scores: [
+          {
+            rank: 1,
+            userId: user.userId,
+            displayName: 'John Doe',
+            score: 900,
+            level: 1,
+            createdAt: new Date(),
+            isCurrentUser: true,
+          },
+        ],
+        total: 1,
+        offset: 0,
+        limit: 50,
+      };
+      mockScoresService.getLeaderboardByUniqueUsers.mockResolvedValue(leaderboardResult);
+
+      await controller.submitScore(user, submitDto1);
+      await controller.submitScore(user, submitDto2);
+      const personalBests = await controller.getPersonalBests(user);
+      const leaderboard = await controller.getLeaderboard(gameType, user, {
+        limit: 50,
+        offset: 0,
+      });
+
+      expect(personalBests.personalBests[0].bestScore).toBe(900);
+      expect(leaderboard.scores[0].score).toBe(900);
+    });
+  });
+});

--- a/apps/api/src/games/scores/scores.controller.ts
+++ b/apps/api/src/games/scores/scores.controller.ts
@@ -1,0 +1,108 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { ScoresService } from './scores.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import {
+  SubmitGameScoreDto,
+  GameScoreResponseDto,
+  GameLeaderboardResponseDto,
+  UserPersonalBestsResponseDto,
+  GetLeaderboardQueryDto,
+} from './dto';
+
+@ApiTags('games/scores')
+@Controller('games/scores')
+export class ScoresController {
+  constructor(private scoresService: ScoresService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Submit a game score' })
+  @ApiResponse({
+    status: 201,
+    description: 'Score submitted successfully',
+    type: GameScoreResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid input data',
+  })
+  @Throttle({ default: { ttl: 60000, limit: 20 } })
+  async submitScore(
+    @CurrentUser() user: { userId: string },
+    @Body() dto: SubmitGameScoreDto
+  ): Promise<GameScoreResponseDto> {
+    return this.scoresService.submitScore(user.userId, dto);
+  }
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Get current user's personal best scores for all games" })
+  @ApiResponse({
+    status: 200,
+    description: 'Personal bests retrieved successfully',
+    type: UserPersonalBestsResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  @Throttle({ default: { ttl: 60000, limit: 30 } })
+  async getPersonalBests(
+    @CurrentUser() user: { userId: string }
+  ): Promise<UserPersonalBestsResponseDto> {
+    return this.scoresService.getUserPersonalBests(user.userId);
+  }
+
+  @Get(':gameType')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get top scores for a specific game (leaderboard)' })
+  @ApiParam({
+    name: 'gameType',
+    description: 'Type of game (e.g., embedding-match, token-tetris, prompt-golf)',
+    example: 'embedding-match',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Leaderboard retrieved successfully',
+    type: GameLeaderboardResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  @Throttle({ default: { ttl: 60000, limit: 50 } })
+  async getLeaderboard(
+    @Param('gameType') gameType: string,
+    @CurrentUser() user: { userId: string },
+    @Query() query: GetLeaderboardQueryDto
+  ): Promise<GameLeaderboardResponseDto> {
+    return this.scoresService.getLeaderboardByUniqueUsers(
+      gameType,
+      user.userId,
+      query.limit,
+      query.offset,
+      query.level
+    );
+  }
+}

--- a/apps/api/src/games/scores/scores.module.spec.ts
+++ b/apps/api/src/games/scores/scores.module.spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ScoresModule } from './scores.module';
+import { ScoresController } from './scores.controller';
+import { ScoresService } from './scores.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('ScoresModule', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [ScoresModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        gameScore: {
+          create: jest.fn(),
+          findMany: jest.fn(),
+          findFirst: jest.fn(),
+          findUnique: jest.fn(),
+          count: jest.fn(),
+          delete: jest.fn(),
+        },
+        $queryRawUnsafe: jest.fn(),
+      })
+      .compile();
+  });
+
+  it('should be defined', () => {
+    expect(module).toBeDefined();
+  });
+
+  it('should have ScoresController', () => {
+    const controller = module.get<ScoresController>(ScoresController);
+    expect(controller).toBeDefined();
+  });
+
+  it('should have ScoresService', () => {
+    const service = module.get<ScoresService>(ScoresService);
+    expect(service).toBeDefined();
+  });
+
+  it('should export ScoresService', () => {
+    const service = module.get<ScoresService>(ScoresService);
+    expect(service).toBeInstanceOf(ScoresService);
+  });
+});

--- a/apps/api/src/games/scores/scores.module.ts
+++ b/apps/api/src/games/scores/scores.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ScoresController } from './scores.controller';
+import { ScoresService } from './scores.service';
+import { PrismaModule } from '../../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ScoresController],
+  providers: [ScoresService],
+  exports: [ScoresService],
+})
+export class ScoresModule {}

--- a/apps/api/src/games/scores/scores.service.spec.ts
+++ b/apps/api/src/games/scores/scores.service.spec.ts
@@ -1,0 +1,485 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ScoresService } from './scores.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { NotFoundException } from '@nestjs/common';
+
+describe('ScoresService', () => {
+  let service: ScoresService;
+
+  const mockPrismaService = {
+    gameScore: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      count: jest.fn(),
+      delete: jest.fn(),
+    },
+    $queryRawUnsafe: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ScoresService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ScoresService>(ScoresService);
+
+    // Clear all mocks before each test
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('submitScore', () => {
+    it('should successfully submit a score', async () => {
+      const userId = 'user123';
+      const dto = {
+        gameType: 'embedding-match',
+        score: 850,
+        level: 1,
+        metadata: { timeRemaining: 45 },
+      };
+
+      const mockCreatedScore = {
+        id: 'score123',
+        userId,
+        gameType: dto.gameType,
+        score: dto.score,
+        level: dto.level,
+        metadata: dto.metadata,
+        createdAt: new Date(),
+        user: {
+          id: userId,
+          displayName: 'John Doe',
+        },
+      };
+
+      mockPrismaService.gameScore.create.mockResolvedValue(mockCreatedScore);
+
+      const result = await service.submitScore(userId, dto);
+
+      expect(result).toEqual({
+        id: mockCreatedScore.id,
+        userId: mockCreatedScore.userId,
+        displayName: mockCreatedScore.user.displayName,
+        gameType: mockCreatedScore.gameType,
+        score: mockCreatedScore.score,
+        level: mockCreatedScore.level,
+        metadata: mockCreatedScore.metadata,
+        createdAt: mockCreatedScore.createdAt,
+      });
+
+      expect(mockPrismaService.gameScore.create).toHaveBeenCalledWith({
+        data: {
+          userId,
+          gameType: dto.gameType,
+          score: dto.score,
+          level: dto.level,
+          metadata: dto.metadata,
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              displayName: true,
+            },
+          },
+        },
+      });
+    });
+
+    it('should submit score without optional fields', async () => {
+      const userId = 'user123';
+      const dto = {
+        gameType: 'token-tetris',
+        score: 1200,
+      };
+
+      const mockCreatedScore = {
+        id: 'score456',
+        userId,
+        gameType: dto.gameType,
+        score: dto.score,
+        level: null,
+        metadata: {},
+        createdAt: new Date(),
+        user: {
+          id: userId,
+          displayName: 'Jane Doe',
+        },
+      };
+
+      mockPrismaService.gameScore.create.mockResolvedValue(mockCreatedScore);
+
+      const result = await service.submitScore(userId, dto);
+
+      expect(result.level).toBeUndefined();
+      // metadata is set to undefined when not provided
+      expect(result.metadata).toBeUndefined();
+      expect(mockPrismaService.gameScore.create).toHaveBeenCalledWith({
+        data: {
+          userId,
+          gameType: dto.gameType,
+          score: dto.score,
+          level: undefined,
+          metadata: undefined,
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              displayName: true,
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('getLeaderboard', () => {
+    it('should return leaderboard with top scores', async () => {
+      const gameType = 'embedding-match';
+      const userId = 'user123';
+      const limit = 10;
+      const offset = 0;
+
+      const mockScores = [
+        {
+          id: 'score1',
+          userId: 'user1',
+          score: 1000,
+          level: 1,
+          createdAt: new Date(),
+          user: { id: 'user1', displayName: 'User One' },
+        },
+        {
+          id: 'score2',
+          userId: userId,
+          score: 850,
+          level: 1,
+          createdAt: new Date(),
+          user: { id: userId, displayName: 'Current User' },
+        },
+      ];
+
+      mockPrismaService.gameScore.findMany.mockResolvedValue(mockScores);
+      mockPrismaService.gameScore.count.mockResolvedValue(2);
+
+      const result = await service.getLeaderboard(gameType, userId, limit, offset);
+
+      expect(result.gameType).toBe(gameType);
+      expect(result.scores).toHaveLength(2);
+      expect(result.scores[0].rank).toBe(1);
+      expect(result.scores[0].score).toBe(1000);
+      expect(result.scores[1].rank).toBe(2);
+      expect(result.scores[1].isCurrentUser).toBe(true);
+      expect(result.total).toBe(2);
+      expect(result.offset).toBe(offset);
+      expect(result.limit).toBe(limit);
+    });
+
+    it('should filter by level when provided', async () => {
+      const gameType = 'embedding-match';
+      const userId = 'user123';
+      const level = 2;
+
+      mockPrismaService.gameScore.findMany.mockResolvedValue([]);
+      mockPrismaService.gameScore.count.mockResolvedValue(0);
+
+      await service.getLeaderboard(gameType, userId, 10, 0, level);
+
+      expect(mockPrismaService.gameScore.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { gameType, level },
+        })
+      );
+    });
+
+    it('should handle pagination correctly', async () => {
+      const gameType = 'embedding-match';
+      const userId = 'user123';
+      const limit = 5;
+      const offset = 10;
+
+      const mockScores = Array.from({ length: 5 }, (_, i) => ({
+        id: `score${i}`,
+        userId: `user${i}`,
+        score: 100 - i,
+        level: 1,
+        createdAt: new Date(),
+        user: { id: `user${i}`, displayName: `User ${i}` },
+      }));
+
+      mockPrismaService.gameScore.findMany.mockResolvedValue(mockScores);
+      mockPrismaService.gameScore.count.mockResolvedValue(50);
+
+      const result = await service.getLeaderboard(gameType, userId, limit, offset);
+
+      expect(result.scores[0].rank).toBe(11); // offset + 1
+      expect(result.scores[4].rank).toBe(15); // offset + 5
+    });
+  });
+
+  describe('getLeaderboardByUniqueUsers', () => {
+    it('should return best score per user', async () => {
+      const gameType = 'embedding-match';
+      const userId = 'user123';
+
+      const mockRawScores = [
+        {
+          id: 'score1',
+          user_id: 'user1',
+          game_type: gameType,
+          score: 1000,
+          level: 1,
+          metadata: {},
+          created_at: new Date().toISOString(),
+          display_name: 'User One',
+          rn: 1,
+        },
+        {
+          id: 'score2',
+          user_id: userId,
+          game_type: gameType,
+          score: 850,
+          level: 1,
+          metadata: {},
+          created_at: new Date().toISOString(),
+          display_name: 'Current User',
+          rn: 1,
+        },
+      ];
+
+      const mockCountResult = [{ count: BigInt(2) }];
+
+      mockPrismaService.$queryRawUnsafe
+        .mockResolvedValueOnce(mockRawScores)
+        .mockResolvedValueOnce(mockCountResult);
+
+      const result = await service.getLeaderboardByUniqueUsers(gameType, userId, 10, 0);
+
+      expect(result.scores).toHaveLength(2);
+      expect(result.scores[0].rank).toBe(1);
+      expect(result.scores[1].isCurrentUser).toBe(true);
+      expect(result.total).toBe(2);
+    });
+
+    it('should filter by level in unique users leaderboard', async () => {
+      const gameType = 'embedding-match';
+      const userId = 'user123';
+      const level = 2;
+
+      mockPrismaService.$queryRawUnsafe
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ count: BigInt(0) }]);
+
+      await service.getLeaderboardByUniqueUsers(gameType, userId, 10, 0, level);
+
+      expect(mockPrismaService.$queryRawUnsafe).toHaveBeenCalledWith(
+        expect.stringContaining('AND gs.level = $2'),
+        gameType,
+        level,
+        10,
+        0
+      );
+    });
+  });
+
+  describe('getUserPersonalBests', () => {
+    it('should return personal bests for all games', async () => {
+      const userId = 'user123';
+
+      const mockGameTypes = [{ gameType: 'embedding-match' }, { gameType: 'token-tetris' }];
+
+      const mockBestScore1 = {
+        id: 'score1',
+        userId,
+        gameType: 'embedding-match',
+        score: 850,
+        level: 1,
+        metadata: {},
+        createdAt: new Date(),
+      };
+
+      const mockBestScore2 = {
+        id: 'score2',
+        userId,
+        gameType: 'token-tetris',
+        score: 1200,
+        level: null,
+        metadata: {},
+        createdAt: new Date(),
+      };
+
+      mockPrismaService.gameScore.findMany.mockResolvedValue(mockGameTypes);
+      mockPrismaService.gameScore.findFirst
+        .mockResolvedValueOnce(mockBestScore1)
+        .mockResolvedValueOnce(mockBestScore2);
+      mockPrismaService.gameScore.count.mockResolvedValueOnce(5).mockResolvedValueOnce(3);
+
+      const result = await service.getUserPersonalBests(userId);
+
+      expect(result.personalBests).toHaveLength(2);
+      expect(result.personalBests[0].gameType).toBe('embedding-match');
+      expect(result.personalBests[0].bestScore).toBe(850);
+      expect(result.personalBests[0].totalAttempts).toBe(5);
+      expect(result.personalBests[1].gameType).toBe('token-tetris');
+      expect(result.personalBests[1].bestScore).toBe(1200);
+      expect(result.personalBests[1].totalAttempts).toBe(3);
+    });
+
+    it('should return empty array if user has no scores', async () => {
+      const userId = 'user123';
+
+      mockPrismaService.gameScore.findMany.mockResolvedValue([]);
+
+      const result = await service.getUserPersonalBests(userId);
+
+      expect(result.personalBests).toEqual([]);
+    });
+  });
+
+  describe('getUserPersonalBestForGame', () => {
+    it('should return personal best for specific game', async () => {
+      const userId = 'user123';
+      const gameType = 'embedding-match';
+
+      const mockBestScore = {
+        id: 'score1',
+        userId,
+        gameType,
+        score: 850,
+        level: 1,
+        metadata: {},
+        createdAt: new Date(),
+      };
+
+      mockPrismaService.gameScore.findFirst.mockResolvedValue(mockBestScore);
+      mockPrismaService.gameScore.count.mockResolvedValue(10);
+
+      const result = await service.getUserPersonalBestForGame(userId, gameType);
+
+      expect(result).not.toBeNull();
+      expect(result?.gameType).toBe(gameType);
+      expect(result?.bestScore).toBe(850);
+      expect(result?.totalAttempts).toBe(10);
+    });
+
+    it('should return null if user has no scores for game', async () => {
+      const userId = 'user123';
+      const gameType = 'embedding-match';
+
+      mockPrismaService.gameScore.findFirst.mockResolvedValue(null);
+
+      const result = await service.getUserPersonalBestForGame(userId, gameType);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getUserRank', () => {
+    it('should return user rank based on best score', async () => {
+      const userId = 'user123';
+      const gameType = 'embedding-match';
+
+      const mockUserBestScore = {
+        id: 'score1',
+        userId,
+        gameType,
+        score: 850,
+        level: 1,
+        metadata: {},
+        createdAt: new Date(),
+      };
+
+      const mockCountResult = [{ count: BigInt(2) }];
+
+      mockPrismaService.gameScore.findFirst.mockResolvedValue(mockUserBestScore);
+      mockPrismaService.$queryRawUnsafe.mockResolvedValue(mockCountResult);
+
+      const rank = await service.getUserRank(userId, gameType);
+
+      expect(rank).toBe(3); // 2 better + 1
+    });
+
+    it('should return 0 if user has no scores', async () => {
+      const userId = 'user123';
+      const gameType = 'embedding-match';
+
+      mockPrismaService.gameScore.findFirst.mockResolvedValue(null);
+
+      const rank = await service.getUserRank(userId, gameType);
+
+      expect(rank).toBe(0);
+    });
+
+    it('should filter by level when calculating rank', async () => {
+      const userId = 'user123';
+      const gameType = 'embedding-match';
+      const level = 2;
+
+      const mockUserBestScore = {
+        id: 'score1',
+        userId,
+        gameType,
+        score: 850,
+        level,
+        metadata: {},
+        createdAt: new Date(),
+      };
+
+      mockPrismaService.gameScore.findFirst.mockResolvedValue(mockUserBestScore);
+      mockPrismaService.$queryRawUnsafe.mockResolvedValue([{ count: BigInt(0) }]);
+
+      await service.getUserRank(userId, gameType, level);
+
+      expect(mockPrismaService.gameScore.findFirst).toHaveBeenCalledWith({
+        where: { userId, gameType, level },
+        orderBy: { score: 'desc' },
+      });
+    });
+  });
+
+  describe('deleteScore', () => {
+    it('should successfully delete a score', async () => {
+      const scoreId = 'score123';
+
+      const mockScore = {
+        id: scoreId,
+        userId: 'user123',
+        gameType: 'embedding-match',
+        score: 850,
+        level: 1,
+        metadata: {},
+        createdAt: new Date(),
+      };
+
+      mockPrismaService.gameScore.findUnique.mockResolvedValue(mockScore);
+      mockPrismaService.gameScore.delete.mockResolvedValue(mockScore);
+
+      await service.deleteScore(scoreId);
+
+      expect(mockPrismaService.gameScore.delete).toHaveBeenCalledWith({
+        where: { id: scoreId },
+      });
+    });
+
+    it('should throw NotFoundException if score does not exist', async () => {
+      const scoreId = 'nonexistent';
+
+      mockPrismaService.gameScore.findUnique.mockResolvedValue(null);
+
+      await expect(service.deleteScore(scoreId)).rejects.toThrow(NotFoundException);
+      expect(mockPrismaService.gameScore.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/games/scores/scores.service.ts
+++ b/apps/api/src/games/scores/scores.service.ts
@@ -1,0 +1,340 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+import {
+  SubmitGameScoreDto,
+  GameScoreResponseDto,
+  GameLeaderboardResponseDto,
+  LeaderboardScoreDto,
+  UserPersonalBestsResponseDto,
+  PersonalBestDto,
+} from './dto';
+
+@Injectable()
+export class ScoresService {
+  private readonly logger = new Logger(ScoresService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Submit a new game score
+   */
+  async submitScore(userId: string, dto: SubmitGameScoreDto): Promise<GameScoreResponseDto> {
+    this.logger.log(
+      `Submitting score for user ${userId}, game ${dto.gameType}, score ${dto.score}`
+    );
+
+    const gameScore = await this.prisma.gameScore.create({
+      data: {
+        userId,
+        gameType: dto.gameType,
+        score: dto.score,
+        level: dto.level,
+        metadata: dto.metadata ? (dto.metadata as Prisma.InputJsonValue) : undefined,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            displayName: true,
+          },
+        },
+      },
+    });
+
+    const metadata = gameScore.metadata as Record<string, unknown>;
+    const hasMetadata = metadata && Object.keys(metadata).length > 0;
+
+    return {
+      id: gameScore.id,
+      userId: gameScore.userId,
+      displayName: gameScore.user.displayName,
+      gameType: gameScore.gameType,
+      score: gameScore.score,
+      level: gameScore.level || undefined,
+      metadata: hasMetadata ? metadata : undefined,
+      createdAt: gameScore.createdAt,
+    };
+  }
+
+  /**
+   * Get top scores for a specific game type (leaderboard)
+   */
+  async getLeaderboard(
+    gameType: string,
+    userId: string,
+    limit: number = 50,
+    offset: number = 0,
+    level?: number
+  ): Promise<GameLeaderboardResponseDto> {
+    this.logger.log(`Getting leaderboard for game ${gameType}, level ${level || 'all'}`);
+
+    // Build where clause
+    const where: { gameType: string; level?: number } = { gameType };
+    if (level) {
+      where.level = level;
+    }
+
+    // Get top scores with user information
+    const topScores = await this.prisma.gameScore.findMany({
+      where,
+      orderBy: { score: 'desc' },
+      skip: offset,
+      take: limit,
+      include: {
+        user: {
+          select: {
+            id: true,
+            displayName: true,
+          },
+        },
+      },
+    });
+
+    // Get total count
+    const total = await this.prisma.gameScore.count({ where });
+
+    // Format scores with ranking
+    const scores: LeaderboardScoreDto[] = topScores.map((score, index) => ({
+      rank: offset + index + 1,
+      userId: score.user.id,
+      displayName: score.user.displayName,
+      score: score.score,
+      level: score.level || undefined,
+      createdAt: score.createdAt,
+      isCurrentUser: score.user.id === userId,
+    }));
+
+    return {
+      gameType,
+      scores,
+      total,
+      offset,
+      limit,
+    };
+  }
+
+  /**
+   * Get top scores by unique users (best score per user)
+   */
+  async getLeaderboardByUniqueUsers(
+    gameType: string,
+    userId: string,
+    limit: number = 50,
+    offset: number = 0,
+    level?: number
+  ): Promise<GameLeaderboardResponseDto> {
+    this.logger.log(
+      `Getting unique user leaderboard for game ${gameType}, level ${level || 'all'}`
+    );
+
+    // Build where clause
+    const where: { gameType: string; level?: number } = { gameType };
+    if (level) {
+      where.level = level;
+    }
+
+    // Get best score per user using raw query for better performance
+    const query = `
+      WITH ranked_scores AS (
+        SELECT
+          gs.*,
+          u.display_name,
+          ROW_NUMBER() OVER (PARTITION BY gs.user_id ORDER BY gs.score DESC) as rn
+        FROM game_scores gs
+        JOIN users u ON gs.user_id = u.id
+        WHERE gs.game_type = $1
+        ${level ? 'AND gs.level = $2' : ''}
+      )
+      SELECT * FROM ranked_scores
+      WHERE rn = 1
+      ORDER BY score DESC
+      LIMIT $${level ? '3' : '2'} OFFSET $${level ? '4' : '3'}
+    `;
+
+    const params = level ? [gameType, level, limit, offset] : [gameType, limit, offset];
+
+    interface RawScore {
+      id: string;
+      user_id: string;
+      game_type: string;
+      score: number;
+      level: number | null;
+      metadata: unknown;
+      created_at: string;
+      display_name: string;
+      rn: number;
+    }
+
+    const topScores = await this.prisma.$queryRawUnsafe<RawScore[]>(query, ...params);
+
+    // Get total unique users for this game
+    const countQuery = `
+      SELECT COUNT(DISTINCT user_id) as count
+      FROM game_scores
+      WHERE game_type = $1
+      ${level ? 'AND level = $2' : ''}
+    `;
+    const countParams = level ? [gameType, level] : [gameType];
+    const countResult = await this.prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+      countQuery,
+      ...countParams
+    );
+    const total = Number(countResult[0]?.count || 0);
+
+    // Format scores with ranking
+    const scores: LeaderboardScoreDto[] = topScores.map((score, index) => ({
+      rank: offset + index + 1,
+      userId: score.user_id,
+      displayName: score.display_name,
+      score: score.score,
+      level: score.level || undefined,
+      createdAt: new Date(score.created_at),
+      isCurrentUser: score.user_id === userId,
+    }));
+
+    return {
+      gameType,
+      scores,
+      total,
+      offset,
+      limit,
+    };
+  }
+
+  /**
+   * Get user's personal best scores for all games
+   */
+  async getUserPersonalBests(userId: string): Promise<UserPersonalBestsResponseDto> {
+    this.logger.log(`Getting personal bests for user ${userId}`);
+
+    // Get all game types the user has played
+    const gameTypes = await this.prisma.gameScore.findMany({
+      where: { userId },
+      select: { gameType: true },
+      distinct: ['gameType'],
+    });
+
+    const personalBests: PersonalBestDto[] = [];
+
+    for (const { gameType } of gameTypes) {
+      // Get best score for this game type
+      const bestScore = await this.prisma.gameScore.findFirst({
+        where: { userId, gameType },
+        orderBy: { score: 'desc' },
+      });
+
+      // Get total attempts
+      const totalAttempts = await this.prisma.gameScore.count({
+        where: { userId, gameType },
+      });
+
+      if (bestScore) {
+        personalBests.push({
+          gameType,
+          bestScore: bestScore.score,
+          level: bestScore.level || undefined,
+          achievedAt: bestScore.createdAt,
+          totalAttempts,
+        });
+      }
+    }
+
+    return {
+      personalBests,
+    };
+  }
+
+  /**
+   * Get user's personal best for a specific game
+   */
+  async getUserPersonalBestForGame(
+    userId: string,
+    gameType: string
+  ): Promise<PersonalBestDto | null> {
+    this.logger.log(`Getting personal best for user ${userId}, game ${gameType}`);
+
+    const bestScore = await this.prisma.gameScore.findFirst({
+      where: { userId, gameType },
+      orderBy: { score: 'desc' },
+    });
+
+    if (!bestScore) {
+      return null;
+    }
+
+    const totalAttempts = await this.prisma.gameScore.count({
+      where: { userId, gameType },
+    });
+
+    return {
+      gameType,
+      bestScore: bestScore.score,
+      level: bestScore.level || undefined,
+      achievedAt: bestScore.createdAt,
+      totalAttempts,
+    };
+  }
+
+  /**
+   * Get user's rank for a specific game
+   */
+  async getUserRank(userId: string, gameType: string, level?: number): Promise<number> {
+    const where: { gameType: string; level?: number } = { gameType };
+    if (level) {
+      where.level = level;
+    }
+
+    // Get user's best score
+    const userBestScore = await this.prisma.gameScore.findFirst({
+      where: { userId, ...where },
+      orderBy: { score: 'desc' },
+    });
+
+    if (!userBestScore) {
+      return 0;
+    }
+
+    // Count how many unique users have a better score
+    const betterScoresQuery = `
+      SELECT COUNT(DISTINCT user_id) as count
+      FROM (
+        SELECT user_id, MAX(score) as max_score
+        FROM game_scores
+        WHERE game_type = $1
+        ${level ? 'AND level = $2' : ''}
+        GROUP BY user_id
+      ) as best_scores
+      WHERE max_score > $${level ? '3' : '2'}
+    `;
+
+    const params = level ? [gameType, level, userBestScore.score] : [gameType, userBestScore.score];
+
+    const result = await this.prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+      betterScoresQuery,
+      ...params
+    );
+    const betterCount = Number(result[0]?.count || 0);
+
+    return betterCount + 1;
+  }
+
+  /**
+   * Delete a score (admin only, or for testing)
+   */
+  async deleteScore(scoreId: string): Promise<void> {
+    const score = await this.prisma.gameScore.findUnique({
+      where: { id: scoreId },
+    });
+
+    if (!score) {
+      throw new NotFoundException(`Score with ID ${scoreId} not found`);
+    }
+
+    await this.prisma.gameScore.delete({
+      where: { id: scoreId },
+    });
+
+    this.logger.log(`Deleted score ${scoreId}`);
+  }
+}

--- a/apps/api/src/lessons/lessons.service.spec.ts
+++ b/apps/api/src/lessons/lessons.service.spec.ts
@@ -1310,9 +1310,7 @@ describe('LessonsService', () => {
 
     it('should return context before and after match', async () => {
       const results = await lessonsService.search('tokenization');
-      const matchWithContext = results.find(
-        (r) => r.matchType === 'section' && r.contextBefore
-      );
+      const matchWithContext = results.find((r) => r.matchType === 'section' && r.contextBefore);
       expect(matchWithContext?.contextBefore).toBeDefined();
       expect(matchWithContext?.contextAfter).toBeDefined();
     });

--- a/apps/api/src/users/dto/update-profile.dto.ts
+++ b/apps/api/src/users/dto/update-profile.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, MinLength, MaxLength, Matches } from 'class-validator';
+import { IsOptional, IsString, MinLength, MaxLength, Matches, IsUrl } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateProfileDto {
@@ -15,4 +15,25 @@ export class UpdateProfileDto {
     message: 'El nombre solo puede contener letras, números y espacios',
   })
   displayName?: string;
+
+  @ApiProperty({
+    example: 'https://example.com/avatar.jpg',
+    description: 'URL del avatar del usuario',
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ message: 'La URL del avatar debe ser una cadena de texto' })
+  @IsUrl({}, { message: 'La URL del avatar debe ser una URL válida' })
+  @MaxLength(500, { message: 'La URL del avatar no puede tener más de 500 caracteres' })
+  avatarUrl?: string;
+
+  @ApiProperty({
+    example: 'Apasionado desarrollador de aplicaciones con LLMs',
+    description: 'Biografía del usuario',
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ message: 'La biografía debe ser una cadena de texto' })
+  @MaxLength(500, { message: 'La biografía no puede tener más de 500 caracteres' })
+  bio?: string;
 }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -27,6 +27,8 @@ export class UsersService {
         id: true,
         email: true,
         displayName: true,
+        avatarUrl: true,
+        bio: true,
         createdAt: true,
       },
     });
@@ -56,6 +58,8 @@ export class UsersService {
         id: true,
         email: true,
         displayName: true,
+        avatarUrl: true,
+        bio: true,
         createdAt: true,
       },
     });
@@ -148,16 +152,25 @@ export class UsersService {
       }
     }
 
+    // Validate avatarUrl if provided
+    if (dto.avatarUrl !== undefined && dto.avatarUrl.trim().length === 0) {
+      throw new BadRequestException('La URL del avatar no puede estar vacía');
+    }
+
     // Update user profile
     const updatedUser = await this.prisma.user.update({
       where: { id: userId },
       data: {
         ...(dto.displayName !== undefined && { displayName: dto.displayName.trim() }),
+        ...(dto.avatarUrl !== undefined && { avatarUrl: dto.avatarUrl.trim() || null }),
+        ...(dto.bio !== undefined && { bio: dto.bio.trim() || null }),
       },
       select: {
         id: true,
         email: true,
         displayName: true,
+        avatarUrl: true,
+        bio: true,
         createdAt: true,
       },
     });

--- a/apps/web/app/profile/index.tsx
+++ b/apps/web/app/profile/index.tsx
@@ -1,22 +1,37 @@
 import { View, Text, StyleSheet, ScrollView, Pressable, ActivityIndicator } from 'react-native';
 import { Stack, router } from 'expo-router';
 import { useSelector } from 'react-redux';
+import { useState } from 'react';
 import type { RootState } from '@/store';
-import { useGetProgressQuery, useGetBadgesQuery } from '@/services/api';
+import { useGetProgressQuery, useGetBadgesQuery, useUpdateProfileMutation } from '@/services/api';
 import { Settings } from 'lucide-react-native';
+import { EditProfileModal } from '@/components/profile/EditProfileModal';
 
 export default function ProfileScreen() {
   const user = useSelector((state: RootState) => state.auth.user);
+  const [isModalVisible, setIsModalVisible] = useState(false);
   const {
     data: progress,
     isLoading: progressLoading,
     isError: progressError,
   } = useGetProgressQuery();
   const { data: badges, isLoading: badgesLoading, isError: badgesError } = useGetBadgesQuery();
+  const [updateProfile] = useUpdateProfileMutation();
 
   const handleEditProfile = () => {
-    // Placeholder for future implementation
-    // TODO: Implement edit profile modal
+    setIsModalVisible(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalVisible(false);
+  };
+
+  const handleSaveProfile = async (data: {
+    displayName: string;
+    avatarUrl?: string;
+    bio?: string;
+  }) => {
+    await updateProfile(data).unwrap();
   };
 
   const handleNavigateToSettings = () => {
@@ -54,6 +69,14 @@ export default function ProfileScreen() {
   return (
     <>
       <Stack.Screen options={{ title: 'Perfil' }} />
+      <EditProfileModal
+        visible={isModalVisible}
+        onClose={handleCloseModal}
+        currentDisplayName={user?.displayName || ''}
+        currentAvatarUrl={user?.avatarUrl}
+        currentBio={user?.bio}
+        onSave={handleSaveProfile}
+      />
       <ScrollView style={styles.container}>
         <View style={styles.header}>
           <View style={styles.avatar}>

--- a/apps/web/src/components/games/embedding-match/GameResult.tsx
+++ b/apps/web/src/components/games/embedding-match/GameResult.tsx
@@ -15,6 +15,11 @@ export interface GameResultProps {
   onPlayAgain: () => void;
   onChangeLevel: () => void;
   onGoHome: () => void;
+  isSubmittingScore?: boolean;
+  submissionResult?: {
+    isHighScore: boolean;
+    xpEarned: number;
+  } | null;
 }
 
 export const GameResult: React.FC<GameResultProps> = ({
@@ -28,6 +33,8 @@ export const GameResult: React.FC<GameResultProps> = ({
   onPlayAgain,
   onChangeLevel,
   onGoHome,
+  isSubmittingScore,
+  submissionResult,
 }) => {
   const formatTime = (seconds: number): string => {
     const mins = Math.floor(seconds / 60);
@@ -123,6 +130,21 @@ export const GameResult: React.FC<GameResultProps> = ({
             <Text style={styles.levelValue}>{level.charAt(0).toUpperCase() + level.slice(1)}</Text>
           </View>
         </View>
+
+        {/* Score Submission Status */}
+        {isSubmittingScore && (
+          <View style={styles.submissionStatus}>
+            <Text style={styles.submittingText}>Submitting score...</Text>
+          </View>
+        )}
+        {submissionResult && (
+          <View style={styles.submissionStatus}>
+            <Text style={styles.submittedText}>
+              {submissionResult.isHighScore ? '🎉 New High Score!' : 'Score Submitted!'}
+            </Text>
+            <Text style={styles.xpText}>+{submissionResult.xpEarned} XP</Text>
+          </View>
+        )}
 
         {/* Actions */}
         <View style={styles.actions}>
@@ -251,6 +273,31 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '700',
     color: '#f8fafc',
+  },
+  submissionStatus: {
+    backgroundColor: '#0f172a',
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 2,
+    borderColor: '#10b981',
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  submittingText: {
+    fontSize: 14,
+    color: '#94a3b8',
+    fontWeight: '500',
+  },
+  submittedText: {
+    fontSize: 16,
+    color: '#10b981',
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  xpText: {
+    fontSize: 18,
+    color: '#3b82f6',
+    fontWeight: '700',
   },
   actions: {
     gap: 12,

--- a/apps/web/src/components/games/embedding-match/__tests__/GameResult.test.tsx
+++ b/apps/web/src/components/games/embedding-match/__tests__/GameResult.test.tsx
@@ -15,6 +15,8 @@ describe('GameResult', () => {
     onPlayAgain: jest.fn(),
     onChangeLevel: jest.fn(),
     onGoHome: jest.fn(),
+    isSubmittingScore: false,
+    submissionResult: null,
   };
 
   it('should render victory message', () => {
@@ -87,5 +89,28 @@ describe('GameResult', () => {
     const { queryByText } = render(<GameResult {...defaultProps} isVictory={false} />);
     // Stars should not be visible for non-victory
     expect(queryByText('Perfect!')).toBeFalsy();
+  });
+
+  it('should show submitting state when score is being submitted', () => {
+    const { getByText } = render(<GameResult {...defaultProps} isSubmittingScore={true} />);
+    expect(getByText('Submitting score...')).toBeTruthy();
+  });
+
+  it('should show submission result when score is submitted', () => {
+    const submissionResult = { isHighScore: false, xpEarned: 25 };
+    const { getByText } = render(
+      <GameResult {...defaultProps} submissionResult={submissionResult} />
+    );
+    expect(getByText('Score Submitted!')).toBeTruthy();
+    expect(getByText('+25 XP')).toBeTruthy();
+  });
+
+  it('should show high score message when achieving high score', () => {
+    const submissionResult = { isHighScore: true, xpEarned: 50 };
+    const { getByText } = render(
+      <GameResult {...defaultProps} submissionResult={submissionResult} />
+    );
+    expect(getByText('🎉 New High Score!')).toBeTruthy();
+    expect(getByText('+50 XP')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/profile/__tests__/EditProfileModal.test.tsx
+++ b/apps/web/src/components/profile/__tests__/EditProfileModal.test.tsx
@@ -10,6 +10,8 @@ describe('EditProfileModal', () => {
     visible: true,
     onClose: mockOnClose,
     currentDisplayName: 'John Doe',
+    currentAvatarUrl: 'https://example.com/avatar.jpg',
+    currentBio: 'This is my bio',
     onSave: mockOnSave,
   };
 
@@ -27,7 +29,6 @@ describe('EditProfileModal', () => {
     it('should not render modal content when visible is false', () => {
       const { queryByText } = render(<EditProfileModal {...defaultProps} visible={false} />);
 
-      // Modal component exists in DOM but content shouldn't be visible
       expect(queryByText('Edit Profile')).toBeNull();
     });
 
@@ -43,11 +44,17 @@ describe('EditProfileModal', () => {
       expect(getByTestId('close-button')).toBeTruthy();
     });
 
-    it('should render input field with label', () => {
+    it('should render all input fields with labels', () => {
       const { getByText, getByTestId } = render(<EditProfileModal {...defaultProps} />);
 
       expect(getByText('Display Name')).toBeTruthy();
       expect(getByTestId('display-name-input')).toBeTruthy();
+
+      expect(getByText('Avatar URL (optional)')).toBeTruthy();
+      expect(getByTestId('avatar-url-input')).toBeTruthy();
+
+      expect(getByText('Bio (optional)')).toBeTruthy();
+      expect(getByTestId('bio-input')).toBeTruthy();
     });
 
     it('should render cancel and save buttons', () => {
@@ -57,30 +64,41 @@ describe('EditProfileModal', () => {
       expect(getByTestId('save-button')).toBeTruthy();
     });
 
-    it('should render character count', () => {
-      const { getByText } = render(<EditProfileModal {...defaultProps} />);
+    it('should render character counts', () => {
+      const { getAllByText } = render(<EditProfileModal {...defaultProps} />);
 
-      expect(getByText(/\d+ \/ 50 characters/)).toBeTruthy();
+      const characterCounts = getAllByText(/\d+ \/ \d+ characters/);
+      expect(characterCounts.length).toBeGreaterThan(0);
     });
   });
 
   describe('Initial State', () => {
-    it('should display current display name in input', () => {
+    it('should display current values in inputs', () => {
       const { getByDisplayValue } = render(<EditProfileModal {...defaultProps} />);
 
       expect(getByDisplayValue('John Doe')).toBeTruthy();
+      expect(getByDisplayValue('https://example.com/avatar.jpg')).toBeTruthy();
+      expect(getByDisplayValue('This is my bio')).toBeTruthy();
     });
 
-    it('should show correct character count for initial value', () => {
-      const { getByText } = render(<EditProfileModal {...defaultProps} />);
+    it('should handle missing optional fields', () => {
+      const { getByTestId } = render(
+        <EditProfileModal {...defaultProps} currentAvatarUrl={undefined} currentBio={undefined} />
+      );
 
-      expect(getByText('8 / 50 characters')).toBeTruthy();
+      const avatarInput = getByTestId('avatar-url-input');
+      const bioInput = getByTestId('bio-input');
+
+      expect(avatarInput.props.value).toBe('');
+      expect(bioInput.props.value).toBe('');
     });
 
-    it('should not show error message initially', () => {
+    it('should not show error messages initially', () => {
       const { queryByTestId } = render(<EditProfileModal {...defaultProps} />);
 
       expect(queryByTestId('display-name-input-error')).toBeNull();
+      expect(queryByTestId('avatar-url-input-error')).toBeNull();
+      expect(queryByTestId('bio-input-error')).toBeNull();
     });
 
     it('should not show success message initially', () => {
@@ -90,21 +108,13 @@ describe('EditProfileModal', () => {
     });
   });
 
-  describe('Input Validation', () => {
+  describe('Display Name Validation', () => {
     it('should update display name on text change', () => {
       const { getByTestId, getByDisplayValue } = render(<EditProfileModal {...defaultProps} />);
 
       fireEvent.changeText(getByTestId('display-name-input'), 'Jane Smith');
 
       expect(getByDisplayValue('Jane Smith')).toBeTruthy();
-    });
-
-    it('should update character count when typing', () => {
-      const { getByTestId, getByText } = render(<EditProfileModal {...defaultProps} />);
-
-      fireEvent.changeText(getByTestId('display-name-input'), 'A');
-
-      expect(getByText('1 / 50 characters')).toBeTruthy();
     });
 
     it('should show error for empty display name', async () => {
@@ -153,25 +163,14 @@ describe('EditProfileModal', () => {
     });
 
     it('should accept valid display name with 2 characters', async () => {
+      mockOnSave.mockResolvedValue(undefined);
       const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
 
       fireEvent.changeText(getByTestId('display-name-input'), 'AB');
       fireEvent.press(getByTestId('save-button'));
 
       await waitFor(() => {
-        expect(mockOnSave).toHaveBeenCalledWith('AB');
-      });
-    });
-
-    it('should accept valid display name with 50 characters', async () => {
-      const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
-
-      const maxName = 'A'.repeat(50);
-      fireEvent.changeText(getByTestId('display-name-input'), maxName);
-      fireEvent.press(getByTestId('save-button'));
-
-      await waitFor(() => {
-        expect(mockOnSave).toHaveBeenCalledWith(maxName);
+        expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({ displayName: 'AB' }));
       });
     });
 
@@ -180,40 +179,175 @@ describe('EditProfileModal', () => {
         <EditProfileModal {...defaultProps} />
       );
 
-      // Trigger error
       fireEvent.changeText(getByTestId('display-name-input'), '');
       fireEvent.press(getByTestId('save-button'));
 
       expect(getByText('Display name is required')).toBeTruthy();
 
-      // Start typing
       fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
 
       expect(queryByText('Display name is required')).toBeNull();
     });
-
-    it('should trim whitespace from display name before validation', async () => {
-      const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
-
-      fireEvent.changeText(getByTestId('display-name-input'), '  Valid Name  ');
-      fireEvent.press(getByTestId('save-button'));
-
-      await waitFor(() => {
-        expect(mockOnSave).toHaveBeenCalledWith('Valid Name');
-      });
-    });
   });
 
-  describe('Save Functionality', () => {
-    it('should call onSave with new display name', async () => {
+  describe('Avatar URL Validation', () => {
+    it('should update avatar URL on text change', () => {
+      const { getByTestId, getByDisplayValue } = render(<EditProfileModal {...defaultProps} />);
+
+      fireEvent.changeText(getByTestId('avatar-url-input'), 'https://new.com/avatar.png');
+
+      expect(getByDisplayValue('https://new.com/avatar.png')).toBeTruthy();
+    });
+
+    it('should accept empty avatar URL', async () => {
       mockOnSave.mockResolvedValue(undefined);
       const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
 
+      fireEvent.changeText(getByTestId('avatar-url-input'), '');
       fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
       fireEvent.press(getByTestId('save-button'));
 
       await waitFor(() => {
-        expect(mockOnSave).toHaveBeenCalledWith('New Name');
+        expect(mockOnSave).toHaveBeenCalledWith(
+          expect.objectContaining({ displayName: 'New Name', avatarUrl: undefined })
+        );
+      });
+    });
+
+    it('should show error for invalid URL', async () => {
+      const { getByTestId, getByText } = render(<EditProfileModal {...defaultProps} />);
+
+      fireEvent.changeText(getByTestId('avatar-url-input'), 'not-a-valid-url');
+      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
+      fireEvent.press(getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(getByText('Please enter a valid URL')).toBeTruthy();
+      });
+    });
+
+    it('should accept valid URL', async () => {
+      mockOnSave.mockResolvedValue(undefined);
+      const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
+
+      fireEvent.changeText(getByTestId('avatar-url-input'), 'https://valid.com/image.jpg');
+      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
+      fireEvent.press(getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            displayName: 'New Name',
+            avatarUrl: 'https://valid.com/image.jpg',
+          })
+        );
+      });
+    });
+
+    it('should clear error when user starts typing', () => {
+      const { getByTestId, getByText, queryByText } = render(
+        <EditProfileModal {...defaultProps} />
+      );
+
+      fireEvent.changeText(getByTestId('avatar-url-input'), 'invalid');
+      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
+      fireEvent.press(getByTestId('save-button'));
+
+      expect(getByText('Please enter a valid URL')).toBeTruthy();
+
+      fireEvent.changeText(getByTestId('avatar-url-input'), 'https://valid.com/avatar.jpg');
+
+      expect(queryByText('Please enter a valid URL')).toBeNull();
+    });
+  });
+
+  describe('Bio Validation', () => {
+    it('should update bio on text change', () => {
+      const { getByTestId, getByDisplayValue } = render(<EditProfileModal {...defaultProps} />);
+
+      fireEvent.changeText(getByTestId('bio-input'), 'New bio text');
+
+      expect(getByDisplayValue('New bio text')).toBeTruthy();
+    });
+
+    it('should accept empty bio', async () => {
+      mockOnSave.mockResolvedValue(undefined);
+      const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
+
+      fireEvent.changeText(getByTestId('bio-input'), '');
+      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
+      fireEvent.press(getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith(
+          expect.objectContaining({ displayName: 'New Name', bio: undefined })
+        );
+      });
+    });
+
+    it('should show error for bio exceeding 500 characters', async () => {
+      const { getByTestId, getByText } = render(<EditProfileModal {...defaultProps} />);
+
+      const longBio = 'A'.repeat(501);
+      fireEvent.changeText(getByTestId('bio-input'), longBio);
+      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
+      fireEvent.press(getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(getByText('Bio must not exceed 500 characters')).toBeTruthy();
+      });
+    });
+
+    it('should accept bio with 500 characters', async () => {
+      mockOnSave.mockResolvedValue(undefined);
+      const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
+
+      const maxBio = 'A'.repeat(500);
+      fireEvent.changeText(getByTestId('bio-input'), maxBio);
+      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
+      fireEvent.press(getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith(
+          expect.objectContaining({ displayName: 'New Name', bio: maxBio })
+        );
+      });
+    });
+
+    it('should clear error when user starts typing', () => {
+      const { getByTestId, getByText, queryByText } = render(
+        <EditProfileModal {...defaultProps} />
+      );
+
+      const longBio = 'A'.repeat(501);
+      fireEvent.changeText(getByTestId('bio-input'), longBio);
+      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
+      fireEvent.press(getByTestId('save-button'));
+
+      expect(getByText('Bio must not exceed 500 characters')).toBeTruthy();
+
+      fireEvent.changeText(getByTestId('bio-input'), 'Valid bio');
+
+      expect(queryByText('Bio must not exceed 500 characters')).toBeNull();
+    });
+  });
+
+  describe('Save Functionality', () => {
+    it('should call onSave with all fields', async () => {
+      mockOnSave.mockResolvedValue(undefined);
+      const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
+
+      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
+      fireEvent.changeText(getByTestId('avatar-url-input'), 'https://new.com/avatar.jpg');
+      fireEvent.changeText(getByTestId('bio-input'), 'New bio');
+      fireEvent.press(getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith({
+          displayName: 'New Name',
+          avatarUrl: 'https://new.com/avatar.jpg',
+          bio: 'New bio',
+        });
       });
     });
 
@@ -238,7 +372,6 @@ describe('EditProfileModal', () => {
       fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
       fireEvent.press(getByTestId('save-button'));
 
-      // Check that buttons are disabled
       expect(getByTestId('save-button')).toBeTruthy();
       expect(getByTestId('cancel-button')).toBeTruthy();
 
@@ -302,7 +435,7 @@ describe('EditProfileModal', () => {
       });
     });
 
-    it('should not call onSave if display name has not changed', async () => {
+    it('should not call onSave if no changes made', async () => {
       const { getByTestId, getByText } = render(<EditProfileModal {...defaultProps} />);
 
       fireEvent.press(getByTestId('save-button'));
@@ -314,14 +447,21 @@ describe('EditProfileModal', () => {
       expect(mockOnSave).not.toHaveBeenCalled();
     });
 
-    it('should not call onSave if display name is invalid', async () => {
+    it('should trim whitespace from all fields before saving', async () => {
+      mockOnSave.mockResolvedValue(undefined);
       const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
 
-      fireEvent.changeText(getByTestId('display-name-input'), '');
+      fireEvent.changeText(getByTestId('display-name-input'), '  Valid Name  ');
+      fireEvent.changeText(getByTestId('avatar-url-input'), '  https://example.com/avatar.jpg  ');
+      fireEvent.changeText(getByTestId('bio-input'), '  Valid bio  ');
       fireEvent.press(getByTestId('save-button'));
 
       await waitFor(() => {
-        expect(mockOnSave).not.toHaveBeenCalled();
+        expect(mockOnSave).toHaveBeenCalledWith({
+          displayName: 'Valid Name',
+          avatarUrl: 'https://example.com/avatar.jpg',
+          bio: 'Valid bio',
+        });
       });
     });
   });
@@ -343,20 +483,24 @@ describe('EditProfileModal', () => {
       expect(mockOnClose).toHaveBeenCalled();
     });
 
-    it('should reset display name to original value on cancel', () => {
+    it('should reset all fields to original values on cancel', () => {
       const { getByTestId, getByDisplayValue, rerender } = render(
         <EditProfileModal {...defaultProps} />
       );
 
       fireEvent.changeText(getByTestId('display-name-input'), 'Changed Name');
+      fireEvent.changeText(getByTestId('avatar-url-input'), 'https://changed.com/avatar.jpg');
+      fireEvent.changeText(getByTestId('bio-input'), 'Changed bio');
       fireEvent.press(getByTestId('cancel-button'));
 
       rerender(<EditProfileModal {...defaultProps} visible={true} />);
 
       expect(getByDisplayValue('John Doe')).toBeTruthy();
+      expect(getByDisplayValue('https://example.com/avatar.jpg')).toBeTruthy();
+      expect(getByDisplayValue('This is my bio')).toBeTruthy();
     });
 
-    it('should clear error message on cancel', () => {
+    it('should clear error messages on cancel', () => {
       const { getByTestId, getByText, queryByText, rerender } = render(
         <EditProfileModal {...defaultProps} />
       );
@@ -381,7 +525,6 @@ describe('EditProfileModal', () => {
 
       fireEvent.press(getByTestId('cancel-button'));
 
-      // onClose should not be called while saving
       expect(mockOnClose).not.toHaveBeenCalled();
 
       await waitFor(() => {
@@ -399,17 +542,27 @@ describe('EditProfileModal', () => {
       rerender(<EditProfileModal {...defaultProps} visible={true} />);
 
       expect(getByDisplayValue('John Doe')).toBeTruthy();
-      expect(getByTestId('display-name-input')).toBeTruthy();
+      expect(getByDisplayValue('https://example.com/avatar.jpg')).toBeTruthy();
+      expect(getByDisplayValue('This is my bio')).toBeTruthy();
     });
 
-    it('should update input when currentDisplayName prop changes', () => {
+    it('should update inputs when props change', () => {
       const { getByDisplayValue, rerender } = render(<EditProfileModal {...defaultProps} />);
 
       expect(getByDisplayValue('John Doe')).toBeTruthy();
 
-      rerender(<EditProfileModal {...defaultProps} currentDisplayName="Jane Smith" />);
+      rerender(
+        <EditProfileModal
+          {...defaultProps}
+          currentDisplayName="Jane Smith"
+          currentAvatarUrl="https://new.com/avatar.jpg"
+          currentBio="New bio"
+        />
+      );
 
       expect(getByDisplayValue('Jane Smith')).toBeTruthy();
+      expect(getByDisplayValue('https://new.com/avatar.jpg')).toBeTruthy();
+      expect(getByDisplayValue('New bio')).toBeTruthy();
     });
 
     it('should handle onRequestClose', () => {
@@ -439,69 +592,6 @@ describe('EditProfileModal', () => {
     });
   });
 
-  describe('Edge Cases', () => {
-    it('should handle very long display names', () => {
-      const longName = 'A'.repeat(100);
-      const { getByTestId, getByText } = render(<EditProfileModal {...defaultProps} />);
-
-      fireEvent.changeText(getByTestId('display-name-input'), longName);
-
-      // Input component will accept the text, but validation will catch it
-      // Character count will show the actual length
-      expect(getByText(/\d+ \/ 50 characters/)).toBeTruthy();
-    });
-
-    it('should handle special characters in display name', async () => {
-      mockOnSave.mockResolvedValue(undefined);
-      const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
-
-      const specialName = 'João Ñoño 山田太郎';
-      fireEvent.changeText(getByTestId('display-name-input'), specialName);
-      fireEvent.press(getByTestId('save-button'));
-
-      await waitFor(() => {
-        expect(mockOnSave).toHaveBeenCalledWith(specialName);
-      });
-    });
-
-    it('should handle numbers in display name', async () => {
-      mockOnSave.mockResolvedValue(undefined);
-      const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
-
-      fireEvent.changeText(getByTestId('display-name-input'), 'User123');
-      fireEvent.press(getByTestId('save-button'));
-
-      await waitFor(() => {
-        expect(mockOnSave).toHaveBeenCalledWith('User123');
-      });
-    });
-
-    it('should handle empty string as currentDisplayName', () => {
-      const { getByTestId } = render(<EditProfileModal {...defaultProps} currentDisplayName="" />);
-
-      const input = getByTestId('display-name-input');
-      expect(input.props.value).toBe('');
-    });
-
-    it('should clear success message when typing after success', async () => {
-      mockOnSave.mockResolvedValue(undefined);
-      const { getByTestId, getByText, queryByText } = render(
-        <EditProfileModal {...defaultProps} />
-      );
-
-      fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
-      fireEvent.press(getByTestId('save-button'));
-
-      await waitFor(() => {
-        expect(getByText('Profile updated successfully!')).toBeTruthy();
-      });
-
-      fireEvent.changeText(getByTestId('display-name-input'), 'Another Name');
-
-      expect(queryByText('Profile updated successfully!')).toBeNull();
-    });
-  });
-
   describe('Accessibility', () => {
     it('should have proper testIDs for all interactive elements', () => {
       const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
@@ -509,26 +599,33 @@ describe('EditProfileModal', () => {
       expect(getByTestId('edit-profile-modal')).toBeTruthy();
       expect(getByTestId('close-button')).toBeTruthy();
       expect(getByTestId('display-name-input')).toBeTruthy();
+      expect(getByTestId('avatar-url-input')).toBeTruthy();
+      expect(getByTestId('bio-input')).toBeTruthy();
       expect(getByTestId('cancel-button')).toBeTruthy();
       expect(getByTestId('save-button')).toBeTruthy();
     });
 
-    it('should auto-focus input when modal opens', () => {
+    it('should auto-focus display name input when modal opens', () => {
       const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
 
       const input = getByTestId('display-name-input');
       expect(input.props.autoFocus).toBe(true);
     });
 
-    it('should disable input while saving', async () => {
+    it('should disable inputs while saving', async () => {
       mockOnSave.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 100)));
       const { getByTestId } = render(<EditProfileModal {...defaultProps} />);
 
       fireEvent.changeText(getByTestId('display-name-input'), 'New Name');
       fireEvent.press(getByTestId('save-button'));
 
-      const input = getByTestId('display-name-input');
-      expect(input.props.editable).toBe(false);
+      const displayNameInput = getByTestId('display-name-input');
+      const avatarUrlInput = getByTestId('avatar-url-input');
+      const bioInput = getByTestId('bio-input');
+
+      expect(displayNameInput.props.editable).toBe(false);
+      expect(avatarUrlInput.props.editable).toBe(false);
+      expect(bioInput.props.editable).toBe(false);
 
       await waitFor(() => {
         expect(mockOnSave).toHaveBeenCalled();

--- a/apps/web/src/services/__tests__/api.test.ts
+++ b/apps/web/src/services/__tests__/api.test.ts
@@ -1,0 +1,58 @@
+import { apiSlice } from '../api';
+import {
+  useSubmitGameScoreMutation,
+  useGetGameLeaderboardQuery,
+  useGetUserGameScoresQuery,
+} from '../api';
+
+describe('apiSlice - Games Endpoints', () => {
+  describe('submitGameScore', () => {
+    it('should have submitGameScore endpoint', () => {
+      expect(apiSlice.endpoints.submitGameScore).toBeDefined();
+    });
+
+    it('should configure submitGameScore as mutation', () => {
+      const endpoint = apiSlice.endpoints.submitGameScore;
+      expect(endpoint.initiate).toBeDefined();
+      expect(typeof endpoint.initiate).toBe('function');
+    });
+  });
+
+  describe('getGameLeaderboard', () => {
+    it('should have getGameLeaderboard endpoint', () => {
+      expect(apiSlice.endpoints.getGameLeaderboard).toBeDefined();
+    });
+
+    it('should configure getGameLeaderboard as query', () => {
+      const endpoint = apiSlice.endpoints.getGameLeaderboard;
+      expect(endpoint.initiate).toBeDefined();
+      expect(typeof endpoint.initiate).toBe('function');
+    });
+  });
+
+  describe('getUserGameScores', () => {
+    it('should have getUserGameScores endpoint', () => {
+      expect(apiSlice.endpoints.getUserGameScores).toBeDefined();
+    });
+
+    it('should configure getUserGameScores as query', () => {
+      const endpoint = apiSlice.endpoints.getUserGameScores;
+      expect(endpoint.initiate).toBeDefined();
+      expect(typeof endpoint.initiate).toBe('function');
+    });
+  });
+
+  describe('API hooks', () => {
+    it('should export useSubmitGameScoreMutation', () => {
+      expect(useSubmitGameScoreMutation).toBeDefined();
+    });
+
+    it('should export useGetGameLeaderboardQuery', () => {
+      expect(useGetGameLeaderboardQuery).toBeDefined();
+    });
+
+    it('should export useGetUserGameScoresQuery', () => {
+      expect(useGetUserGameScoresQuery).toBeDefined();
+    });
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from './types/badge';
 export * from './types/progress';
 export * from './types/leaderboard';
 export * from './types/quiz';
+export * from './types/game.types';
 export * from './constants/levels';
 export * from './constants/xp';
 export { calculateXpWithMultipliers } from './utils/xp-multipliers';

--- a/packages/shared/src/types/user.ts
+++ b/packages/shared/src/types/user.ts
@@ -2,6 +2,8 @@ export interface User {
   id: string;
   email: string;
   displayName: string;
+  avatarUrl?: string;
+  bio?: string;
   createdAt?: string;
 }
 


### PR DESCRIPTION
## Release Summary

This release includes two major features:

### GAME-001: Game Scores Integration (#148)
- New `GameScore` Prisma model for storing game scores
- Complete `ScoresService` with:
  - Submit scores
  - Get leaderboard (global and by unique users)
  - Get user personal bests
  - Get user rank
- REST API endpoints:
  - `POST /games/scores` - Submit a score
  - `GET /games/scores/me` - Get user's personal bests
  - `GET /games/scores/:gameType` - Get leaderboard for a game
- Frontend integration:
  - TokenTetris auto-submits scores on game over
  - EmbeddingMatch auto-submits scores with metadata
  - Games index shows user high scores

### PROFILE-001: Edit Profile Modal (#149)
- New User fields: `avatarUrl`, `bio`
- `EditProfileModal` component with:
  - Display name editing
  - Avatar URL with validation
  - Bio with character limit (500)
  - Form validation and error handling
- RTK Query integration for profile updates
- Auto-sync auth state after updates

## Test Coverage
- 35 API tests for scores module (96.52% coverage)
- 49 frontend tests for EditProfileModal
- All existing tests passing (1166+ tests)

## Database Migration Required
After deploying, run:
```bash
npm run db:push -w @llmengineer/api
```

## Commits included
- feat: add game scores API and edit profile modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)