### PR TITLE
fix: unify background color to prevent white flash on rotation

### DIFF
--- a/apps/web/app.json
+++ b/apps/web/app.json
@@ -6,28 +6,32 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "llmengineer",
-    "userInterfaceStyle": "automatic",
+    "userInterfaceStyle": "dark",
+    "backgroundColor": "#0f172a",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",
-      "backgroundColor": "#1F2937"
+      "backgroundColor": "#0f172a"
     },
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.llmengineer.app"
+      "bundleIdentifier": "com.llmengineer.app",
+      "backgroundColor": "#0f172a"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#1F2937"
+        "backgroundColor": "#0f172a"
       },
-      "package": "com.llmengineer.app"
+      "package": "com.llmengineer.app",
+      "backgroundColor": "#0f172a"
     },
     "web": {
       "bundler": "metro",
       "output": "single",
-      "favicon": "./assets/favicon.png"
+      "favicon": "./assets/favicon.png",
+      "backgroundColor": "#0f172a"
     },
     "plugins": ["expo-router"],
     "experiments": {

--- a/apps/web/app/(tabs)/badges.tsx
+++ b/apps/web/app/(tabs)/badges.tsx
@@ -243,7 +243,7 @@ function BadgeDetailModal({ badge, onClose }: BadgeDetailModalProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   header: {
     padding: 20,
@@ -447,7 +447,7 @@ const styles = StyleSheet.create({
     color: '#10B981',
   },
   progressContainer: {
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
     padding: 16,
     borderRadius: 12,
     marginBottom: 24,

--- a/apps/web/app/(tabs)/games/index.tsx
+++ b/apps/web/app/(tabs)/games/index.tsx
@@ -204,7 +204,7 @@ function GameCard({ game, onPress }: GameCardProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   header: {
     padding: 20,
@@ -389,7 +389,7 @@ const styles = StyleSheet.create({
     lineHeight: 24,
   },
   unlockRequirementContainer: {
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
     padding: 16,
     borderRadius: 12,
     width: '100%',

--- a/apps/web/app/_layout.tsx
+++ b/apps/web/app/_layout.tsx
@@ -44,7 +44,7 @@ function RootLayoutNav() {
       screenOptions={{
         headerShown: false,
         contentStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
       }}
     />
@@ -65,6 +65,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
 });

--- a/apps/web/app/auth/_layout.tsx
+++ b/apps/web/app/auth/_layout.tsx
@@ -17,14 +17,14 @@ export default function AuthLayout() {
     <Stack
       screenOptions={{
         headerStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
         headerTintColor: '#F9FAFB',
         headerTitleStyle: {
           fontWeight: '600',
         },
         contentStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
       }}
     />

--- a/apps/web/app/auth/login.tsx
+++ b/apps/web/app/auth/login.tsx
@@ -182,7 +182,7 @@ export default function LoginScreen() {
 const styles = StyleSheet.create({
   keyboardView: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   scrollContainer: {
     flexGrow: 1,
@@ -190,7 +190,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 24,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
     justifyContent: 'center',
   },
   header: {

--- a/apps/web/app/auth/register.tsx
+++ b/apps/web/app/auth/register.tsx
@@ -276,7 +276,7 @@ export default function RegisterScreen() {
 const styles = StyleSheet.create({
   keyboardView: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   scrollContainer: {
     flexGrow: 1,
@@ -284,7 +284,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 24,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
     justifyContent: 'center',
   },
   header: {

--- a/apps/web/app/dashboard/_layout.tsx
+++ b/apps/web/app/dashboard/_layout.tsx
@@ -13,11 +13,11 @@ export default function DashboardLayout() {
     <Stack
       screenOptions={{
         headerStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
         headerTintColor: '#F9FAFB',
         contentStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
       }}
     />

--- a/apps/web/app/games/_layout.tsx
+++ b/apps/web/app/games/_layout.tsx
@@ -13,7 +13,7 @@ export default function GamesLayout() {
           fontWeight: 'bold',
         },
         contentStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
       }}
     />

--- a/apps/web/app/games/index.tsx
+++ b/apps/web/app/games/index.tsx
@@ -102,7 +102,7 @@ export default function GamesScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   content: {
     paddingBottom: 40,

--- a/apps/web/app/games/token-tetris.tsx
+++ b/apps/web/app/games/token-tetris.tsx
@@ -27,6 +27,6 @@ export default function TokenTetrisScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
 });

--- a/apps/web/app/index.tsx
+++ b/apps/web/app/index.tsx
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: 24,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   title: {
     fontSize: 32,

--- a/apps/web/app/leaderboard/_layout.tsx
+++ b/apps/web/app/leaderboard/_layout.tsx
@@ -13,11 +13,11 @@ export default function LeaderboardLayout() {
     <Stack
       screenOptions={{
         headerStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
         headerTintColor: '#F9FAFB',
         contentStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
       }}
     />

--- a/apps/web/app/leaderboard/index.tsx
+++ b/apps/web/app/leaderboard/index.tsx
@@ -139,7 +139,7 @@ export default function LeaderboardScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   tabs: {
     flexDirection: 'row',

--- a/apps/web/app/lessons/[id].tsx
+++ b/apps/web/app/lessons/[id].tsx
@@ -157,13 +157,13 @@ export default function LessonDetailScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   errorText: {
     color: '#EF4444',

--- a/apps/web/app/lessons/_layout.tsx
+++ b/apps/web/app/lessons/_layout.tsx
@@ -13,11 +13,11 @@ export default function LessonsLayout() {
     <Stack
       screenOptions={{
         headerStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
         headerTintColor: '#F9FAFB',
         contentStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
       }}
     />

--- a/apps/web/app/lessons/index.tsx
+++ b/apps/web/app/lessons/index.tsx
@@ -217,7 +217,7 @@ export default function LessonsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   content: {
     paddingHorizontal: 30,
@@ -227,7 +227,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   errorText: {
     color: '#EF4444',

--- a/apps/web/app/profile/_layout.tsx
+++ b/apps/web/app/profile/_layout.tsx
@@ -13,11 +13,11 @@ export default function ProfileLayout() {
     <Stack
       screenOptions={{
         headerStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
         headerTintColor: '#F9FAFB',
         contentStyle: {
-          backgroundColor: '#111827',
+          backgroundColor: '#0f172a',
         },
       }}
     />

--- a/apps/web/app/profile/index.tsx
+++ b/apps/web/app/profile/index.tsx
@@ -180,11 +180,11 @@ export default function ProfileScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   loadingContainer: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
     justifyContent: 'center',
     alignItems: 'center',
     gap: 16,
@@ -195,7 +195,7 @@ const styles = StyleSheet.create({
   },
   errorContainer: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
     justifyContent: 'center',
     alignItems: 'center',
     padding: 24,

--- a/apps/web/app/profile/settings.tsx
+++ b/apps/web/app/profile/settings.tsx
@@ -170,7 +170,7 @@ export default function SettingsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#111827',
+    backgroundColor: '#0f172a',
   },
   section: {
     marginTop: 24,


### PR DESCRIPTION
## Summary

Fixes white background appearing on screen rotation by unifying all background colors to `#0f172a` (slate-900).

## Changes

- **app.json**: Added `backgroundColor` at root, iOS, Android, and web levels
- **userInterfaceStyle**: Changed from `automatic` to `dark`
- **All _layout.tsx files**: Updated `contentStyle.backgroundColor` and `headerStyle.backgroundColor`
- **All screen components**: Updated container backgrounds

## Files Changed (20 files)
- `app.json` - Expo configuration
- `app/_layout.tsx` - Root layout
- `app/auth/_layout.tsx`, `login.tsx`, `register.tsx`
- `app/dashboard/_layout.tsx`
- `app/games/_layout.tsx`, `index.tsx`, `token-tetris.tsx`
- `app/leaderboard/_layout.tsx`, `index.tsx`
- `app/lessons/_layout.tsx`, `[id].tsx`, `index.tsx`
- `app/profile/_layout.tsx`, `index.tsx`, `settings.tsx`
- `app/(tabs)/badges.tsx`, `games/index.tsx`
- `app/index.tsx`

## Test Plan
- [x] Lint passes
- [ ] Manual test: Rotate screen on iOS/Android - no white flash
- [ ] Verify dark theme is consistent across all screens

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)