### PR TITLE
fix: restructure lessons to 10 weeks x 2 lessons each

### DIFF
--- a/apps/api/prisma/load-full-content.ts
+++ b/apps/api/prisma/load-full-content.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-console */
 import { PrismaClient } from '@prisma/client';
-// Weeks 1-5 (Lessons 1-10)
+// 10 semanas, 2 lecciones por semana = 20 lecciones total
+// Semanas 1-5 (Lecciones 1-10): Fundamentos
 import { introToLlms, apiBasics } from './content/lessons-1-2';
 import { promptEngineeringBasics, temperatureAndSampling } from './content/lessons-3-4';
 import { systemPrompts, contextManagement } from './content/lessons-5-6';
 import { structuredOutputs, errorHandling } from './content/lessons-7-8';
 import { streamingResponses, costOptimization } from './content/lessons-9-10';
-// Weeks 6-9 (Lessons 11-20)
+// Semanas 6-10 (Lecciones 11-20): Avanzado
 import { ragFundamentals, ragAdvanced } from './content/lessons-11-12';
 import { evaluationBenchmarking, agentsFundamentals } from './content/lessons-13-14';
 import { agentsAdvanced, securityGuardrails } from './content/lessons-15-16';
@@ -15,35 +16,36 @@ import { multimodalModels, localModelsEdge } from './content/lessons-19-20';
 
 const prisma = new PrismaClient();
 
-// Map slug to content (all 20 lessons)
+// Map slug to content (all 20 lessons, 10 weeks x 2)
 const lessonContentMap: Record<string, { sections: unknown[]; quiz?: unknown }> = {
-  // Week 1
+  // Semana 1: Fundamentos
   'intro-to-llms': introToLlms,
   'api-basics': apiBasics,
-  // Week 2
+  // Semana 2: Prompting Básico
   'prompt-engineering-basics': promptEngineeringBasics,
   'temperature-and-sampling': temperatureAndSampling,
-  // Week 3
+  // Semana 3: Contexto y System Prompts
   'system-prompts': systemPrompts,
   'context-management': contextManagement,
-  // Week 4
+  // Semana 4: Outputs y Errores
   'structured-outputs': structuredOutputs,
   'error-handling': errorHandling,
-  // Week 5
+  // Semana 5: Producción Básica
   'streaming-responses': streamingResponses,
   'cost-optimization': costOptimization,
-  // Week 6
+  // Semana 6: RAG
   'rag-fundamentals': ragFundamentals,
   'rag-advanced': ragAdvanced,
-  // Week 7
+  // Semana 7: Evaluación y Agentes Básicos
   'evaluation-benchmarking': evaluationBenchmarking,
   'agents-fundamentals': agentsFundamentals,
-  // Week 8
+  // Semana 8: Agentes Avanzados y Seguridad
   'agents-advanced': agentsAdvanced,
   'security-guardrails': securityGuardrails,
+  // Semana 9: Fine-tuning y MLOps
   'finetuning-adaptation': finetuningAdaptation,
   'production-mlops': productionMlops,
-  // Week 9
+  // Semana 10: Modelos Especializados
   'multimodal-models': multimodalModels,
   'local-models-edge': localModelsEdge,
 };

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -108,9 +108,19 @@ async function seedBadges() {
       isSecret: false,
     },
     {
-      slug: 'week-8-complete',
+      slug: 'week-5-complete',
+      name: 'Mitad del Camino',
+      description: 'Completaste las primeras 5 semanas del curso',
+      icon: '🎯',
+      category: BadgeCategory.completion,
+      requirement: { weekComplete: 5 },
+      xpBonus: 200,
+      isSecret: false,
+    },
+    {
+      slug: 'week-10-complete',
       name: 'Graduado LLM Engineer',
-      description: 'Completaste todo el curso de 8 semanas',
+      description: 'Completaste todo el curso de 10 semanas',
       icon: '🎓',
       category: BadgeCategory.mastery,
       requirement: { allWeeksComplete: true },
@@ -192,6 +202,7 @@ async function seedBadges() {
 
 async function seedLessons() {
   const lessons = [
+    // ==================== SEMANA 1: Fundamentos ====================
     {
       slug: 'intro-to-llms',
       title: 'Introducción a los LLMs',
@@ -229,13 +240,14 @@ async function seedLessons() {
       sections: [],
       isPublished: true,
     },
+    // ==================== SEMANA 2: Prompting Básico ====================
     {
       slug: 'prompt-engineering-basics',
       title: 'Introducción al Prompt Engineering',
       description:
         'Descubre cómo escribir prompts efectivos para obtener mejores respuestas de los LLMs.',
-      week: 1,
-      order: 3,
+      week: 2,
+      order: 1,
       difficulty: Difficulty.beginner,
       xpReward: 100,
       estimatedMinutes: 25,
@@ -247,21 +259,22 @@ async function seedLessons() {
       title: 'Temperature y Parámetros de Sampling',
       description:
         'Aprende a controlar la creatividad y determinismo de las respuestas mediante parámetros.',
-      week: 1,
-      order: 4,
+      week: 2,
+      order: 2,
       difficulty: Difficulty.beginner,
       xpReward: 100,
       estimatedMinutes: 20,
       sections: [],
       isPublished: true,
     },
+    // ==================== SEMANA 3: Contexto y System Prompts ====================
     {
       slug: 'system-prompts',
       title: 'System Prompts y Roles',
       description:
         'Entiende cómo usar system prompts para definir el comportamiento del modelo.',
-      week: 1,
-      order: 5,
+      week: 3,
+      order: 1,
       difficulty: Difficulty.beginner,
       xpReward: 100,
       estimatedMinutes: 20,
@@ -273,21 +286,22 @@ async function seedLessons() {
       title: 'Gestión de Contexto',
       description:
         'Aprende a manejar conversaciones largas y optimizar el uso de tokens.',
-      week: 2,
-      order: 1,
+      week: 3,
+      order: 2,
       difficulty: Difficulty.beginner,
       xpReward: 150,
       estimatedMinutes: 25,
       sections: [],
       isPublished: true,
     },
+    // ==================== SEMANA 4: Outputs y Manejo de Errores ====================
     {
       slug: 'structured-outputs',
       title: 'Outputs Estructurados',
       description:
         'Descubre cómo obtener respuestas en formatos específicos como JSON.',
-      week: 2,
-      order: 2,
+      week: 4,
+      order: 1,
       difficulty: Difficulty.intermediate,
       xpReward: 150,
       estimatedMinutes: 30,
@@ -299,21 +313,22 @@ async function seedLessons() {
       title: 'Manejo de Errores y Rate Limits',
       description:
         'Aprende a manejar errores, timeouts y límites de rate de las APIs.',
-      week: 2,
-      order: 3,
+      week: 4,
+      order: 2,
       difficulty: Difficulty.intermediate,
       xpReward: 150,
       estimatedMinutes: 25,
       sections: [],
       isPublished: true,
     },
+    // ==================== SEMANA 5: Producción Básica ====================
     {
       slug: 'streaming-responses',
       title: 'Streaming de Respuestas',
       description:
         'Implementa streaming para obtener respuestas progresivas en tiempo real.',
-      week: 2,
-      order: 4,
+      week: 5,
+      order: 1,
       difficulty: Difficulty.intermediate,
       xpReward: 150,
       estimatedMinutes: 30,
@@ -325,21 +340,21 @@ async function seedLessons() {
       title: 'Optimización de Costos',
       description:
         'Estrategias para reducir costos de API manteniendo calidad de respuestas.',
-      week: 2,
-      order: 5,
+      week: 5,
+      order: 2,
       difficulty: Difficulty.intermediate,
       xpReward: 150,
       estimatedMinutes: 25,
       sections: [],
       isPublished: true,
     },
-    // Semana 3: RAG
+    // ==================== SEMANA 6: RAG ====================
     {
       slug: 'rag-fundamentals',
       title: 'RAG Fundamentals',
       description:
         'Aprende los fundamentos de Retrieval Augmented Generation: embeddings, vector databases y chunking strategies.',
-      week: 3,
+      week: 6,
       order: 1,
       difficulty: Difficulty.intermediate,
       xpReward: 200,
@@ -352,7 +367,7 @@ async function seedLessons() {
       title: 'RAG Avanzado',
       description:
         'Técnicas avanzadas de RAG: hybrid search, re-ranking, query transformation y evaluación de pipelines.',
-      week: 3,
+      week: 6,
       order: 2,
       difficulty: Difficulty.advanced,
       xpReward: 200,
@@ -360,13 +375,13 @@ async function seedLessons() {
       sections: [],
       isPublished: true,
     },
-    // Semana 4: Evaluation & Agents Basics
+    // ==================== SEMANA 7: Evaluación y Agentes Básicos ====================
     {
       slug: 'evaluation-benchmarking',
       title: 'Evaluación y Benchmarking',
       description:
         'Aprende a evaluar LLMs: métricas automáticas, LLM-as-Judge, benchmarks estándar y evaluación humana.',
-      week: 4,
+      week: 7,
       order: 1,
       difficulty: Difficulty.intermediate,
       xpReward: 200,
@@ -379,7 +394,7 @@ async function seedLessons() {
       title: 'Agentes y Tool Use',
       description:
         'Fundamentos de agentes: function calling, tool use, ReAct pattern y construcción de agentes básicos.',
-      week: 4,
+      week: 7,
       order: 2,
       difficulty: Difficulty.intermediate,
       xpReward: 200,
@@ -387,13 +402,13 @@ async function seedLessons() {
       sections: [],
       isPublished: true,
     },
-    // Semana 5: Agents Advanced & Security
+    // ==================== SEMANA 8: Agentes Avanzados y Seguridad ====================
     {
       slug: 'agents-advanced',
       title: 'Agentes Avanzados',
       description:
         'Sistemas multi-agente, orquestación con LangGraph y CrewAI, memoria a largo plazo y planning.',
-      week: 5,
+      week: 8,
       order: 1,
       difficulty: Difficulty.advanced,
       xpReward: 250,
@@ -406,7 +421,7 @@ async function seedLessons() {
       title: 'Seguridad y Guardrails',
       description:
         'Protege tus aplicaciones LLM: prompt injection, jailbreaking, PII detection y content moderation.',
-      week: 5,
+      week: 8,
       order: 2,
       difficulty: Difficulty.advanced,
       xpReward: 250,
@@ -414,13 +429,13 @@ async function seedLessons() {
       sections: [],
       isPublished: true,
     },
-    // Semana 6: Fine-tuning & MLOps
+    // ==================== SEMANA 9: Fine-tuning y MLOps ====================
     {
       slug: 'finetuning-adaptation',
       title: 'Fine-tuning y Adaptación',
       description:
         'Técnicas de fine-tuning: LoRA, QLoRA, preparación de datasets y cuándo usar fine-tuning vs prompting.',
-      week: 6,
+      week: 9,
       order: 1,
       difficulty: Difficulty.advanced,
       xpReward: 250,
@@ -433,7 +448,7 @@ async function seedLessons() {
       title: 'MLOps para LLMs',
       description:
         'Lleva LLMs a producción: observabilidad, logging, A/B testing, optimización de latencia y costos.',
-      week: 6,
+      week: 9,
       order: 2,
       difficulty: Difficulty.advanced,
       xpReward: 250,
@@ -441,13 +456,13 @@ async function seedLessons() {
       sections: [],
       isPublished: true,
     },
-    // Semana 7: Multimodal
+    // ==================== SEMANA 10: Modelos Especializados ====================
     {
       slug: 'multimodal-models',
       title: 'Modelos Multimodales',
       description:
         'Trabaja con modelos que procesan imágenes, audio y documentos: GPT-4 Vision, Whisper y más.',
-      week: 7,
+      week: 10,
       order: 1,
       difficulty: Difficulty.advanced,
       xpReward: 250,
@@ -455,14 +470,13 @@ async function seedLessons() {
       sections: [],
       isPublished: true,
     },
-    // Semana 8: Local Models
     {
       slug: 'local-models-edge',
       title: 'Modelos Locales y Edge',
       description:
         'Ejecuta LLMs localmente: Ollama, quantización, optimización para edge y casos de uso offline.',
-      week: 8,
-      order: 1,
+      week: 10,
+      order: 2,
       difficulty: Difficulty.advanced,
       xpReward: 250,
       estimatedMinutes: 40,

--- a/apps/api/scripts/fix-week-structure.ts
+++ b/apps/api/scripts/fix-week-structure.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-console */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('🔄 Fixing week 8 and 9 structure...\n');
+
+  // Primero, mover finetuning y production-mlops a semana 9
+  // Pero hay un conflicto porque semana 8 ya tiene 4 lecciones
+
+  // Paso 1: Mover temporalmente a semana 99 para evitar conflictos
+  console.log('Paso 1: Moviendo lecciones temporalmente...');
+
+  await prisma.lesson.update({
+    where: { slug: 'finetuning-adaptation' },
+    data: { week: 99, order: 1 },
+  });
+  console.log('  ✓ finetuning-adaptation → Week 99');
+
+  await prisma.lesson.update({
+    where: { slug: 'production-mlops' },
+    data: { week: 99, order: 2 },
+  });
+  console.log('  ✓ production-mlops → Week 99');
+
+  // Paso 2: Ahora mover a semana 9
+  console.log('\nPaso 2: Moviendo a semana 9...');
+
+  await prisma.lesson.update({
+    where: { slug: 'finetuning-adaptation' },
+    data: { week: 9, order: 1 },
+  });
+  console.log('  ✅ finetuning-adaptation → Week 9, Order 1');
+
+  await prisma.lesson.update({
+    where: { slug: 'production-mlops' },
+    data: { week: 9, order: 2 },
+  });
+  console.log('  ✅ production-mlops → Week 9, Order 2');
+
+  // Verificar estructura final
+  console.log('\n📊 Final structure verification:');
+  const lessons = await prisma.lesson.findMany({
+    select: { slug: true, title: true, week: true, order: true },
+    orderBy: [{ week: 'asc' }, { order: 'asc' }],
+  });
+
+  const byWeek: Record<number, string[]> = {};
+  for (const lesson of lessons) {
+    if (!byWeek[lesson.week]) byWeek[lesson.week] = [];
+    byWeek[lesson.week].push(`${lesson.order}. ${lesson.title}`);
+  }
+
+  for (const [week, weekLessons] of Object.entries(byWeek)) {
+    console.log(`\nSemana ${week} (${weekLessons.length} lecciones):`);
+    weekLessons.forEach((l) => console.log(`  ${l}`));
+  }
+
+  console.log('\n✨ Week structure fix completed!');
+}
+
+main()
+  .catch((e) => {
+    console.error('Fatal error:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/api/scripts/update-weeks.ts
+++ b/apps/api/scripts/update-weeks.ts
@@ -1,0 +1,101 @@
+/* eslint-disable no-console */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// Nueva estructura: 10 semanas x 2 lecciones
+const weekUpdates: Record<string, { week: number; order: number }> = {
+  // Semana 1: Fundamentos
+  'intro-to-llms': { week: 1, order: 1 },
+  'api-basics': { week: 1, order: 2 },
+  // Semana 2: Prompting Básico
+  'prompt-engineering-basics': { week: 2, order: 1 },
+  'temperature-and-sampling': { week: 2, order: 2 },
+  // Semana 3: Contexto y System Prompts
+  'system-prompts': { week: 3, order: 1 },
+  'context-management': { week: 3, order: 2 },
+  // Semana 4: Outputs y Errores
+  'structured-outputs': { week: 4, order: 1 },
+  'error-handling': { week: 4, order: 2 },
+  // Semana 5: Producción Básica
+  'streaming-responses': { week: 5, order: 1 },
+  'cost-optimization': { week: 5, order: 2 },
+  // Semana 6: RAG
+  'rag-fundamentals': { week: 6, order: 1 },
+  'rag-advanced': { week: 6, order: 2 },
+  // Semana 7: Evaluación y Agentes Básicos
+  'evaluation-benchmarking': { week: 7, order: 1 },
+  'agents-fundamentals': { week: 7, order: 2 },
+  // Semana 8: Agentes Avanzados y Seguridad
+  'agents-advanced': { week: 8, order: 1 },
+  'security-guardrails': { week: 8, order: 2 },
+  // Semana 9: Fine-tuning y MLOps
+  'finetuning-adaptation': { week: 9, order: 1 },
+  'production-mlops': { week: 9, order: 2 },
+  // Semana 10: Modelos Especializados
+  'multimodal-models': { week: 10, order: 1 },
+  'local-models-edge': { week: 10, order: 2 },
+};
+
+async function main() {
+  console.log('🔄 Updating lesson week structure to 10 weeks x 2 lessons...\n');
+
+  for (const [slug, { week, order }] of Object.entries(weekUpdates)) {
+    try {
+      const lesson = await prisma.lesson.findUnique({
+        where: { slug },
+        select: { id: true, title: true, week: true, order: true },
+      });
+
+      if (!lesson) {
+        console.log(`⚠️  Lesson not found: ${slug}`);
+        continue;
+      }
+
+      if (lesson.week === week && lesson.order === order) {
+        console.log(`✓ ${slug}: already correct (Week ${week}, Order ${order})`);
+        continue;
+      }
+
+      await prisma.lesson.update({
+        where: { slug },
+        data: { week, order },
+      });
+
+      console.log(
+        `✅ ${slug}: Week ${lesson.week}→${week}, Order ${lesson.order}→${order}`
+      );
+    } catch (error) {
+      console.error(`❌ Error updating ${slug}:`, error);
+    }
+  }
+
+  // Verificar estructura final
+  console.log('\n📊 Final structure verification:');
+  const lessons = await prisma.lesson.findMany({
+    select: { slug: true, title: true, week: true, order: true },
+    orderBy: [{ week: 'asc' }, { order: 'asc' }],
+  });
+
+  const byWeek: Record<number, string[]> = {};
+  for (const lesson of lessons) {
+    if (!byWeek[lesson.week]) byWeek[lesson.week] = [];
+    byWeek[lesson.week].push(`${lesson.order}. ${lesson.title}`);
+  }
+
+  for (const [week, weekLessons] of Object.entries(byWeek)) {
+    console.log(`\nSemana ${week} (${weekLessons.length} lecciones):`);
+    weekLessons.forEach((l) => console.log(`  ${l}`));
+  }
+
+  console.log('\n✨ Week structure update completed!');
+}
+
+main()
+  .catch((e) => {
+    console.error('Fatal error:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- Fixed lesson/week structure from uneven 8 weeks to balanced 10 weeks
- Each week now has exactly 2 lessons (20 total)
- Production database already updated

## Structure
| Semana | Tema | Lecciones |
|--------|------|-----------|
| 1 | Fundamentos | Intro LLMs, API Basics |
| 2 | Prompting | Prompt Engineering, Temperature |
| 3 | Contexto | System Prompts, Context Management |
| 4 | Outputs | Structured Outputs, Error Handling |
| 5 | Producción | Streaming, Cost Optimization |
| 6 | RAG | Fundamentals, Advanced |
| 7 | Evaluación | Benchmarking, Agents Basics |
| 8 | Agentes | Advanced, Security |
| 9 | MLOps | Fine-tuning, Production |
| 10 | Especializados | Multimodal, Local Models |

## Changes
- Updated `seed.ts` with correct week assignments
- Updated `load-full-content.ts` with proper comments
- Added migration scripts for production
- Updated badges for 10-week course

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)