### PR TITLE
fix: connect sidebar to real lesson data from API

### DIFF
--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -1,7 +1,23 @@
 import { View, StyleSheet, Platform } from 'react-native';
+import { useMemo } from 'react';
 import { Sidebar } from './Sidebar';
 import { Navbar } from './Navbar';
 import { useSidebarCollapsed } from '@/hooks/useSidebarCollapsed';
+import { useGetLessonsQuery } from '@/services/api';
+
+// Nombres de las semanas del curso
+const WEEK_TITLES: Record<number, string> = {
+  1: 'Fundamentos',
+  2: 'Prompting Básico',
+  3: 'Contexto',
+  4: 'Outputs y Errores',
+  5: 'Producción Básica',
+  6: 'RAG',
+  7: 'Evaluación y Agentes',
+  8: 'Agentes Avanzados',
+  9: 'Fine-tuning y MLOps',
+  10: 'Modelos Especializados',
+};
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -31,6 +47,34 @@ export function MainLayout({
   onLogout,
 }: MainLayoutProps) {
   const { isCollapsed, toggleCollapsed } = useSidebarCollapsed();
+  const { data: lessons } = useGetLessonsQuery();
+
+  // Transform lessons into modules grouped by week
+  const modules = useMemo(() => {
+    if (!lessons) return [];
+
+    const byWeek: Record<number, { completed: number; total: number }> = {};
+
+    for (const lesson of lessons) {
+      if (!byWeek[lesson.week]) {
+        byWeek[lesson.week] = { completed: 0, total: 0 };
+      }
+      byWeek[lesson.week].total++;
+      if (lesson.isCompleted) {
+        byWeek[lesson.week].completed++;
+      }
+    }
+
+    return Object.entries(byWeek)
+      .sort(([a], [b]) => Number(a) - Number(b))
+      .map(([week, data]) => ({
+        id: week,
+        title: `Semana ${week}: ${WEEK_TITLES[Number(week)] || ''}`,
+        lessonsCompleted: data.completed,
+        totalLessons: data.total,
+        isComplete: data.completed === data.total && data.total > 0,
+      }));
+  }, [lessons]);
 
   // On mobile, don't show sidebar
   if (Platform.OS !== 'web') {
@@ -55,6 +99,7 @@ export function MainLayout({
   return (
     <View style={styles.container}>
       <Sidebar
+        modules={modules}
         currentModuleId={currentModuleId}
         isCollapsed={isCollapsed}
         onToggleCollapse={toggleCollapsed}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -26,18 +26,8 @@ interface SidebarProps {
   onToggleCollapse?: () => void;
 }
 
-const DEFAULT_MODULES: Module[] = [
-  { id: '1', title: 'Setup + Fundamentos', lessonsCompleted: 5, totalLessons: 5, isComplete: true },
-  { id: '2', title: 'Plugins Core + Web', lessonsCompleted: 6, totalLessons: 6, isComplete: true },
-  { id: '3', title: 'Desarrollo + Build', lessonsCompleted: 5, totalLessons: 5, isComplete: true },
-  {
-    id: '4',
-    title: 'Testing + App Store',
-    lessonsCompleted: 0,
-    totalLessons: 4,
-    isComplete: false,
-  },
-];
+// Los módulos reales vienen del MainLayout via useGetLessonsQuery
+const DEFAULT_MODULES: Module[] = [];
 
 const EXPANDED_WIDTH = 260;
 const COLLAPSED_WIDTH = 72;
@@ -133,14 +123,14 @@ export function Sidebar({
         </Pressable>
       </Tooltip>
 
-      {/* Modules Section */}
-      {!isCollapsed && (
+      {/* Weeks/Modules Section */}
+      {!isCollapsed && modules.length > 0 && (
         <View style={styles.sectionHeader}>
-          <Text style={styles.sectionTitle}>MODULOS</Text>
+          <Text style={styles.sectionTitle}>SEMANAS</Text>
         </View>
       )}
 
-      {isCollapsed && <View style={styles.collapsedDivider} />}
+      {isCollapsed && modules.length > 0 && <View style={styles.collapsedDivider} />}
 
       {modules.map((module) => {
         const isActive = currentModuleId === module.id;

--- a/apps/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -102,19 +102,20 @@ describe('Sidebar', () => {
   });
 
   describe('Modules Section', () => {
-    it('should render MODULOS section header', () => {
-      const { getByText } = render(<Sidebar />);
+    it('should render SEMANAS section header when modules provided', () => {
+      const modules = [
+        { id: '1', title: 'Semana 1: Test', lessonsCompleted: 1, totalLessons: 2, isComplete: false },
+      ];
+      const { getByText } = render(<Sidebar modules={modules} />);
 
-      expect(getByText('MODULOS')).toBeTruthy();
+      expect(getByText('SEMANAS')).toBeTruthy();
     });
 
-    it('should render default modules when no modules prop provided', () => {
-      const { getByText } = render(<Sidebar />);
+    it('should not render SEMANAS section when no modules provided', () => {
+      const { queryByText } = render(<Sidebar />);
 
-      expect(getByText('Setup + Fundamentos')).toBeTruthy();
-      expect(getByText('Plugins Core + Web')).toBeTruthy();
-      expect(getByText('Desarrollo + Build')).toBeTruthy();
-      expect(getByText('Testing + App Store')).toBeTruthy();
+      // With empty default modules, SEMANAS header should not appear
+      expect(queryByText('SEMANAS')).toBeNull();
     });
 
     it('should render custom modules when provided', () => {
@@ -364,10 +365,10 @@ describe('Sidebar', () => {
 
   describe('Edge Cases', () => {
     it('should handle empty modules array', () => {
-      const { getByText, queryByText } = render(<Sidebar modules={[]} />);
+      const { queryByText } = render(<Sidebar modules={[]} />);
 
-      expect(getByText('MODULOS')).toBeTruthy();
-      expect(queryByText('Setup + Fundamentos')).toBeNull();
+      // SEMANAS header should not appear when no modules
+      expect(queryByText('SEMANAS')).toBeNull();
     });
 
     it('should handle long module titles with truncation', () => {
@@ -407,10 +408,13 @@ describe('Sidebar', () => {
     });
 
     it('should handle rapid navigation between items', () => {
-      const { getByText } = render(<Sidebar />);
+      const modules = [
+        { id: '1', title: 'Semana 1: Test', lessonsCompleted: 0, totalLessons: 2, isComplete: false },
+      ];
+      const { getByText } = render(<Sidebar modules={modules} />);
 
       fireEvent.press(getByText('LLM Engineer'));
-      fireEvent.press(getByText('Setup + Fundamentos'));
+      fireEvent.press(getByText('Semana 1: Test'));
 
       // Dashboard button now toggles collapse, not navigation
       expect(expoRouter.router.push).toHaveBeenCalledTimes(2);
@@ -470,12 +474,15 @@ describe('Sidebar', () => {
 
   describe('Accessibility', () => {
     it('should render all interactive elements as Pressable', () => {
-      const { getByText } = render(<Sidebar />);
+      const modules = [
+        { id: '1', title: 'Semana 1: Test', lessonsCompleted: 0, totalLessons: 2, isComplete: false },
+      ];
+      const { getByText } = render(<Sidebar modules={modules} />);
 
       // All these should be pressable
       expect(getByText('LLM Engineer')).toBeTruthy();
       expect(getByText('Dashboard')).toBeTruthy();
-      expect(getByText('Setup + Fundamentos')).toBeTruthy();
+      expect(getByText('Semana 1: Test')).toBeTruthy();
     });
 
     it('should maintain consistent module order', () => {
@@ -493,11 +500,14 @@ describe('Sidebar', () => {
 
   describe('Collapsed Mode', () => {
     it('should hide text elements when collapsed', () => {
-      const { queryByText } = render(<Sidebar isCollapsed={true} />);
+      const modules = [
+        { id: '1', title: 'Semana 1: Test', lessonsCompleted: 0, totalLessons: 2, isComplete: false },
+      ];
+      const { queryByText } = render(<Sidebar modules={modules} isCollapsed={true} />);
 
       expect(queryByText('LLM Engineer')).toBeNull();
       expect(queryByText('Dashboard')).toBeNull();
-      expect(queryByText('MODULOS')).toBeNull();
+      expect(queryByText('SEMANAS')).toBeNull();
     });
 
     it('should show text elements when not collapsed', () => {


### PR DESCRIPTION
## Summary
- Sidebar now displays real week data from API instead of hardcoded modules
- Shows all 10 weeks with their proper titles
- Displays user's actual progress per week

## Changes
- `MainLayout.tsx`: Fetches lessons and transforms to modules
- `Sidebar.tsx`: Changed "MODULOS" to "SEMANAS", empty default modules
- Updated tests to reflect new behavior

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)